### PR TITLE
Fix OOM excepton when exporting large datasets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>no.ssb.dapla.dlp.pseudo</groupId>
       <artifactId>dapla-dlp-pseudo-core</artifactId>
-      <version>0.1.7</version>
+      <version>0.1.9</version>
     </dependency>
     <dependency>
       <groupId>no.ssb.dapla.dlp.pseudo.func</groupId>

--- a/src/main/java/no/ssb/dlp/pseudo/service/export/ExportController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/export/ExportController.java
@@ -17,7 +17,6 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.validation.Validated;
-import io.reactivex.Single;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +48,7 @@ public class ExportController {
 
     @Post("/export")
     @ExecuteOn(TaskExecutors.IO)
-    public Single<ExportService.DatasetExportResult> export(@Body @Valid ExportRequest request, Principal principal) {
+    public ExportService.DatasetExportResult export(@Body @Valid ExportRequest request, Principal principal) {
         log.info("Export dataset - user={}, dataset={}", principal.getName(), request.getDatasetPath());
 
         ExportService.DatasetExport datasetExport = ExportService.DatasetExport.builder()

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,8 @@
         </encoder>
     </appender>
 
+    <logger name="no.ssb.dlp.pseudo.core.util" level="TRACE"/>
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
The fix is to use the latest version of dapla-dlp-pseudo-core which uses
a different strategy when zipping the export files.

Also, exporting is now done in separate threads, and the target export paths
are returned upfront.