### PR TITLE
Support data encryption key generation

### DIFF
--- a/doc/requests/examples.http
+++ b/doc/requests/examples.http
@@ -482,3 +482,14 @@ Content-Type: application/json
 
 GET {{base_url}}/metadata
 Authorization: Bearer {{keycloak_token}}
+
+
+### Generate data encryption key
+
+POST {{base_url}}/keys
+Content-Type: application/json
+Authorization: Bearer {{keycloak_token}}
+
+{
+  "kekUri": "{{kek_uri}}"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>no.ssb.dapla.dlp.pseudo</groupId>
       <artifactId>dapla-dlp-pseudo-core</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>no.ssb.avro.convert.core</groupId>

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
@@ -1,0 +1,55 @@
+package no.ssb.dlp.pseudo.service.keys;
+
+import com.google.common.base.Strings;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Error;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.http.hateoas.Link;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
+
+import java.net.URI;
+import java.security.Principal;
+
+@Introspected
+@RequiredArgsConstructor
+@Controller("/keys")
+@Slf4j
+@Secured(SecurityRule.IS_AUTHENTICATED)
+@Tag(name = "Key operations")
+public class KeyController {
+
+    private final KeyService keyService;
+
+    @Post
+    public HttpResponse<EncryptedKeysetWrapper> generateDataEncryptionKey(KeyGenerationRequest request, Principal principal) {
+        log.info(Strings.padEnd(String.format("*** Generate data encryption key"), 80, '*'));
+        log.debug("User: {}\n{}", principal.getName(), request);
+        EncryptedKeysetWrapper keyset = keyService.createNewDataEncryptionKey(request.getKekUri());
+        return HttpResponse.ok(keyset);
+    }
+
+    @Data
+    static class KeyGenerationRequest {
+        private URI kekUri;
+    }
+
+    @Error
+    public HttpResponse<JsonError> unsupportedKeyEncryptionKeyError(HttpRequest request, KeyService.UnsupportedKeyException e) {
+        JsonError error = new JsonError(e.getMessage())
+                .link(Link.SELF, Link.of(request.getUri()));
+        return HttpResponse.<JsonError>badRequest().body(error);
+    }
+
+}

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
@@ -13,6 +13,7 @@ import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.hateoas.Link;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,16 @@ public class KeyController {
 
     private final KeyService keyService;
 
+    @Operation(
+            summary = "Generate DEK",
+            description = """
+            Generate a custom Data Encryption Key (DEK) that can be used for pseudonymization.
+            
+            The generated key will be encrypted (a process known as "wrapping") by the user-specified KEK
+            (Key Encryption Key). If a `kekUri` is not specified, then the default KEK used. This is the
+            preferred default usage when generating new DEKs.
+            """
+    )
     @Post
     public HttpResponse<EncryptedKeysetWrapper> generateDataEncryptionKey(KeyGenerationRequest request, Principal principal) {
         log.info(Strings.padEnd(String.format("*** Generate data encryption key"), 80, '*'));
@@ -42,6 +53,12 @@ public class KeyController {
 
     @Data
     static class KeyGenerationRequest {
+        /**
+         * URI to the key encryption key stored in KMS.
+         * <p>
+         * E.g. gcp-kms://projects/my-project-id/locations/europe-north1/keyRings/my-keyring/cryptoKeys/my-kek
+         * </p>
+         */
         private URI kekUri;
     }
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
@@ -45,9 +45,10 @@ public class KeyController {
     )
     @Post
     public HttpResponse<EncryptedKeysetWrapper> generateDataEncryptionKey(KeyGenerationRequest request, Principal principal) {
-        log.info(Strings.padEnd(String.format("*** Generate data encryption key"), 80, '*'));
-        log.debug("User: {}\n{}", principal.getName(), request);
+        log.info(Strings.padEnd(String.format("*** Generate data encryption key ***"), 80, '*'));
+        log.debug("User: {}", principal.getName());
         EncryptedKeysetWrapper keyset = keyService.createNewDataEncryptionKey(request.getKekUri());
+        log.debug("Generated key:\n{}", keyset.toJson());
         return HttpResponse.ok(keyset);
     }
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
@@ -1,11 +1,9 @@
 package no.ssb.dlp.pseudo.service.keys;
 
 import com.google.common.base.Strings;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Error;
 import io.micronaut.http.annotation.Post;

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyService.java
@@ -1,0 +1,60 @@
+package no.ssb.dlp.pseudo.service.keys;
+
+import lombok.RequiredArgsConstructor;
+import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
+import no.ssb.dlp.pseudo.core.util.Json;
+import no.ssb.dlp.pseudo.core.util.TinkUtil;
+import no.ssb.dlp.pseudo.service.tink.KmsConfig;
+
+import javax.inject.Singleton;
+import java.net.URI;
+
+@Singleton
+@RequiredArgsConstructor
+public class KeyService {
+
+    private final KmsConfig kmsConfig;
+
+    public EncryptedKeysetWrapper createNewDataEncryptionKey(URI kekUri) {
+        kekUri = validateOrGetDefaultKekUri(kekUri);
+
+        try {
+            String keysetJson = TinkUtil.newWrappedKeyJson(kekUri.toString());
+            EncryptedKeysetWrapper keyset = Json.toObject(EncryptedKeysetWrapper.class, keysetJson);
+            keyset.setKekUri(kekUri);
+            return keyset;
+        }
+        catch (Exception e) {
+            throw new KeyGenerationException("Error generating data encryption key (encrypted by %s)".formatted(kekUri), e);
+        }
+    }
+
+    private URI validateOrGetDefaultKekUri(final URI kekUri) {
+        if (kekUri == null) {
+            return getDefaultKekUri();
+        }
+
+        if (! kmsConfig.getKeyUris().stream()
+                .anyMatch(u -> u.equals(kekUri))) {
+            throw new UnsupportedKeyException("'%s' is not a configured key encryption key".formatted(kekUri));
+        }
+
+        return kekUri;
+    }
+
+    private URI getDefaultKekUri() {
+        return kmsConfig.getKeyUris().get(0);
+    }
+
+    public static class UnsupportedKeyException extends RuntimeException {
+        public UnsupportedKeyException(String message) {
+            super(message);
+        }
+    }
+
+    public static class KeyGenerationException extends RuntimeException {
+        public KeyGenerationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -386,14 +386,11 @@ public class PseudoController {
         private char[] password;
     }
 
-    // TODO: Validate that this works
-    @Error(status = HttpStatus.BAD_REQUEST)
+    @Error
     public HttpResponse<JsonError> unknownPseudoKeyError(HttpRequest request, NoSuchPseudoKeyException e) {
         JsonError error = new JsonError(e.getMessage())
                 .link(Link.SELF, Link.of(request.getUri()));
-
-        return HttpResponse.<JsonError>status(HttpStatus.BAD_REQUEST, e.getMessage())
-                .body(error);
+        return HttpResponse.<JsonError>badRequest().body(error);
     }
 
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/tink/KmsConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/tink/KmsConfig.java
@@ -18,7 +18,6 @@ public class KmsConfig {
     /**
      * URIs to registered KMS KEKs (Key Encryption Keys)
      */
-    @NotEmpty
     private List<URI> keyUris = new ArrayList<>();
 
     /**

--- a/src/main/java/no/ssb/dlp/pseudo/service/tink/KmsConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/tink/KmsConfig.java
@@ -1,19 +1,24 @@
 package no.ssb.dlp.pseudo.service.tink;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.core.annotation.Introspected;
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
 @ConfigurationProperties("gcp.kms")
 @Data
+@Context
 public class KmsConfig {
 
     /**
      * URIs to registered KMS KEKs (Key Encryption Keys)
      */
+    @NotEmpty
     private List<URI> keyUris = new ArrayList<>();
 
     /**

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,6 @@
 micronaut:
   application.name: pseudo-service
+
   server:
     port: 18080
 
@@ -11,5 +12,5 @@ services:
 
 gcp:
   kms:
-    master-kek: gcp-kms://projects/{PROJECT_ID}/locations/europe-north1/keyRings/{KEYRING_NAME}/cryptoKeys/{KEY_NAME}
-
+    key-uris:
+      - gcp-kms://projects/{PROJECT_ID}/locations/europe-north1/keyRings/{KEYRING_NAME}/cryptoKeys/{KEY_NAME}


### PR DESCRIPTION
This PR adds a `/keys` REST endpoint, that provides functionality for creating new Data Encryption Keys, wrapped by a user specified Key Encryption Key (KEK).

It is possible to use the generated DEK as a custom key for pseudonymization.

If a kek is not specified, then the default KEK is used.

<img width="971" alt="image" src="https://user-images.githubusercontent.com/21902/208121117-0bc3df85-d2aa-45e5-af78-c037b1d299aa.png">

Example payload:
```json
{
  "kekUri": "gcp-kms://projects/some-project/locations/europe-north1/keyRings/some-keyring/cryptoKeys/some-kek-1",
  "encryptedKeyset": "CjQAp9...OQ=",
  "keysetInfo": {
    "primaryKeyId": 123456789,
    "keyInfo": [
      {
        "typeUrl": "type.googleapis.com/google.crypto.tink.AesSivKey",
        "status": "ENABLED",
        "keyId": 123456789,
        "outputPrefixType": "TINK"
      }
    ]
  }
}
```
