### PR TITLE
Add build file for Cloud Run

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,0 +1,15 @@
+
+steps:
+  # Docker Build
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 
+           'europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/dapla-dlp-pseudo', 
+           '.']
+    
+  # Docker Push
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 
+           'europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/dapla-dlp-pseudo']
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,7 @@
 
 steps:
 
+  # Pull jar-file from Artifact Registry instead building from source
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,12 +1,5 @@
 
 steps:
-  - name: 'gcr.io/cloud-builders/gcloud'
-    entrypoint: 'bash'
-    args:
-      - "-c"
-      - |
-          gcloud auth list
- 
   - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: 'mvn'
     args: ['package','-Dmaven.test.skip=true', '-P ssb-bip']

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,5 +1,8 @@
 
 steps:
+  - name: 'gcr.io/cloud-builders/mvn'
+     entrypoint: mvn
+     args: ['package','-Dmaven.test.skip=true']
 
   # Pull jar-file from Artifact Registry instead of building from source.
   - name: 'gcr.io/cloud-builders/gcloud'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,6 @@
 
 steps:
-  - name: 'gcr.io/cloud-builders/mvn'
+  - name: 'gcr.io/cloud-builders/mvn:gcloud'
     entrypoint: 'mvn'
     args: ['package','-Dmaven.test.skip=true', '-P ssb-bip']
 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -4,8 +4,6 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
-           'europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/dapla-dlp-pseudo', 
-           '.']
       - "-c"
       - |
           curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,11 +1,11 @@
 
 steps:
 
-  - name: maven:3.8-openjdk-17
+  - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: mvn
     args: ['test']
 
-  - name: maven:3.8-openjdk-17
+  - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: mvn
     args: ['package','-Dmaven.test.skip=true']
 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,7 +1,7 @@
 
 steps:
 
-  # Pull jar-file from Artifact Registry instead building from source. Mimic target folder after build.
+  # Pull jar-file from Artifact Registry instead of building from source.
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
@@ -12,13 +12,13 @@ steps:
           curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
           -L https://europe-north1-docker.pkg.dev/artifact-registry-14da/maven-snapshots/no.ssb.dlp.pseudo.service/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar
 
-  # Docker Build
+  # Build Docker image
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 
            'europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/dapla-dlp-pseudo', 
            '.']
     
-  # Docker Push
+  # Push Docker image to the ssb-docker Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args: ['push', 
            'europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/dapla-dlp-pseudo']

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,7 +1,7 @@
 
 steps:
 
-  # Pull jar-file from Artifact Registry instead building from source
+  # Pull jar-file from Artifact Registry instead building from source. Mimic target folder after build.
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -6,7 +6,8 @@ steps:
     args:
       - "-c"
       - |
-          curl --oauth2-bearer "$(gcloud auth print-access-token)" -o dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
+          mkdir target
+          curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
           -L https://europe-north1-docker.pkg.dev/artifact-registry-14da/maven-snapshots/no.ssb.dlp.pseudo.service/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar
 
   # Docker Build

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,5 +1,14 @@
 
 steps:
+
+  - name: maven:3.8-openjdk-17
+    entrypoint: mvn
+    args: ['test']
+
+  - name: maven:3.8-openjdk-17
+    entrypoint: mvn
+    args: ['package','-Dmaven.test.skip=true']
+
   # Docker Build
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,6 @@
 
 steps:
-  - name: 'gcr.io/cloud-builders/mvn:gcloud'
+  - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
       - "-c"

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -6,7 +6,7 @@ steps:
     args:
       - "-c"
       - |
-          curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
+          curl --oauth2-bearer "$(gcloud auth print-access-token)" -o dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
           -L https://europe-north1-docker.pkg.dev/artifact-registry-14da/maven-snapshots/no.ssb.dlp.pseudo.service/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar
 
   # Docker Build

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,10 @@
 
 steps:
   - name: 'gcr.io/cloud-builders/mvn:gcloud'
+    entrypoint: 'bash'
+    args: ['gcloud auth list']
+ 
+  - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: 'mvn'
     args: ['package','-Dmaven.test.skip=true', '-P ssb-bip']
 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -2,7 +2,10 @@
 steps:
   - name: 'gcr.io/cloud-builders/mvn:gcloud'
     entrypoint: 'bash'
-    args: ['gcloud auth list']
+    args:
+      - "-c"
+      - |
+          gcloud auth list
  
   - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: 'mvn'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,6 @@
 
 steps:
-  - name: 'gcr.io/cloud-builders/mvn'
+  - name: 'gcr.io/cloud-builders/mvn:gcloud'
     entrypoint: 'mvn'
     args: ['package','-Dmaven.test.skip=true']
 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,19 +1,10 @@
 
 steps:
+
+  # Build jar file
   - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: 'mvn'
     args: ['package','-Dmaven.test.skip=true', '-P ssb-bip']
-
-  # Pull jar-file from Artifact Registry instead of building from source.
-  - name: 'gcr.io/cloud-builders/gcloud'
-    entrypoint: 'bash'
-    args:
-      - "-c"
-      - |
-          mkdir -p target/classes
-          cp src/main/resources/logback.xml target/classes/.
-          curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
-          -L https://europe-north1-docker.pkg.dev/artifact-registry-14da/maven-snapshots/no.ssb.dlp.pseudo.service/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar
 
   # Build Docker image
   - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,8 +1,8 @@
 
 steps:
-  - name: 'gcr.io/cloud-builders/mvn:gcloud'
+  - name: 'gcr.io/cloud-builders/mvn'
     entrypoint: 'mvn'
-    args: ['package','-Dmaven.test.skip=true']
+    args: ['package','-Dmaven.test.skip=true', '-P ssb-bip']
 
   # Pull jar-file from Artifact Registry instead of building from source.
   - name: 'gcr.io/cloud-builders/gcloud'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -6,7 +6,8 @@ steps:
     args:
       - "-c"
       - |
-          mkdir target
+          mkdir -p target/classes
+          cp src/main/resources/logback.xml target/classes/.
           curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
           -L https://europe-north1-docker.pkg.dev/artifact-registry-14da/maven-snapshots/no.ssb.dlp.pseudo.service/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar
 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,8 +1,8 @@
 
 steps:
   - name: 'gcr.io/cloud-builders/mvn'
-     entrypoint: mvn
-     args: ['package','-Dmaven.test.skip=true']
+    entrypoint: 'mvn'
+    args: ['package','-Dmaven.test.skip=true']
 
   # Pull jar-file from Artifact Registry instead of building from source.
   - name: 'gcr.io/cloud-builders/gcloud'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,13 +1,15 @@
 
 steps:
 
-  - name: 'gcr.io/cloud-builders/mvn'
-    entrypoint: mvn
-    args: ['test']
-
-  - name: 'gcr.io/cloud-builders/mvn'
-    entrypoint: mvn
-    args: ['package','-Dmaven.test.skip=true']
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+           'europe-north1-docker.pkg.dev/artifact-registry-14da/ssb-docker/ssb/statistikktjenester/automation/dapla-dlp-pseudo', 
+           '.']
+      - "-c"
+      - |
+          curl --oauth2-bearer "$(gcloud auth print-access-token)" -o target/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar \
+          -L https://europe-north1-docker.pkg.dev/artifact-registry-14da/maven-snapshots/no.ssb.dlp.pseudo.service/dapla-dlp-pseudo-service-2.1.1-SNAPSHOT.jar
 
   # Docker Build
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
This PR is part of adding a Cloud Build trigger for dapla-dlp-pseudo-service. See https://github.com/statisticsnorway/dapla-felles-iac/pull/43