### PR TITLE
Add default configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM azul/zulu-openjdk:17
 RUN apt-get -qq update && apt-get -y --no-install-recommends install curl
 COPY target/dapla-dlp-pseudo-service-*.jar dapla-dlp-pseudo-service.jar
 COPY target/classes/logback*.xml /conf/
+COPY conf/bootstrap.yml /conf/
+COPY conf/application.yml /conf/
 EXPOSE 10210
 CMD ["java", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005", "-Dcom.sun.management.jmxremote", "-Dmicronaut.bootstrap.context=true", "-jar", "dapla-dlp-pseudo-service.jar"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build-all: build-mvn build-docker ## Build all and create docker image
 
 .PHONY: build-mvn
 build-mvn: ## Build project and install to you local maven repo
-	./mvnw clean install
+	./mvnw clean install -P ssb-bip
 
 .PHONY: build-docker
 build-docker: ## Build dev docker image

--- a/conf/application.yml
+++ b/conf/application.yml
@@ -1,0 +1,37 @@
+micronaut:
+  application:
+    name: dapla-pseudo-service
+  server:
+    port: 10210
+    cors.enabled: true
+  thread-selection: AUTO
+  max-request-size: 2gb
+  multipart:
+    max-file-size: 2gb
+  caches:
+    secrets:
+      expire-after-access: 15m
+  router:
+    static-resources:
+      swagger:
+        paths: classpath:META-INF/swagger
+        mapping: /api-docs/**
+      swagger-ui:
+        paths: classpath:META-INF/swagger/views/swagger-ui
+        mapping: /api-docs/swagger-ui/**
+      rapidoc:
+        paths: classpath:META-INF/swagger/views/rapidoc
+        mapping: /api-docs/rapidoc/**
+      redoc:
+        paths: classpath:META-INF/swagger/views/redoc
+        mapping: /api-docs/redoc/**
+endpoints:
+  prometheus:
+    sensitive: false
+  info:
+    enabled: true
+    sensitive: false
+logger:
+  levels:
+    io.micronaut.security: INFO
+    no.ssb.dlp.pseudo.service: DEBUG

--- a/conf/bootstrap.yml
+++ b/conf/bootstrap.yml
@@ -1,0 +1,5 @@
+micronaut:
+  application:
+    name: pseudo-service
+  config-client:
+    enabled: true


### PR DESCRIPTION
This enables environment specific differences to be more easily overridden by environment variables. Cloud Run cannot set up configuration files as volume mounts, and therefore needs to configure the service via environment variables.