### PR TITLE
Extract sid-client configuration to separate config.

### DIFF
--- a/conf/application-local.yml
+++ b/conf/application-local.yml
@@ -40,21 +40,11 @@ micronaut:
           jwks:
             keycloak-staging:
               url: 'https://keycloak.staging-bip-app.ssb.no/auth/realms/ssb/protocol/openid-connect/certs'
-      propagation:
-        enabled: true
-        service-id-regex: "sid-service"
-
 
   object-storage:
     gcp:
       sid:
         bucket: ssb-dev-dapla-pseudo-service-data-export
-
-  http:
-    services:
-      sid-service:
-        url: 'http://localhost:10210'
-        path: '/local-sid'
 
 endpoints:
   info:

--- a/conf/application-sid-client.yml
+++ b/conf/application-sid-client.yml
@@ -1,0 +1,13 @@
+micronaut:
+  security:
+    token:
+      propagation:
+        enabled: true
+        service-id-regex: "sid-service"
+
+  http:
+    services:
+      sid-service:
+        url: 'http://localhost:10210'
+        path: '/local-sid'
+

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
@@ -1,6 +1,7 @@
 package no.ssb.dlp.pseudo.service.security;
 
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requirements;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.security.token.DefaultRolesFinder;
@@ -16,8 +17,9 @@ import java.util.Map;
 @Singleton
 @Replaces(bean = DefaultRolesFinder.class)
 @RequiredArgsConstructor
-@Requires(notEnv = {
-        Environment.TEST
+@Requirements({
+        @Requires(notEnv = Environment.TEST),
+        @Requires(notEquals = "endpoints.cloud-run.enabled", value = "true")
 })
 public class CustomRolesFinder implements RolesFinder {
 


### PR DESCRIPTION
When the pseudo-service application is deployed to Cloud Run, this will make it easier to configure the SID-service endpoint by simply overriding the URL and PATH variables.

The property `endpoints.cloud-run.enabled` is now also used to toggle CustomRolesFinder.