### PR TITLE
Disable IdTokenFilter in k8s environment

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/IdTokenFilter.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/IdTokenFilter.java
@@ -3,6 +3,7 @@ package no.ssb.dlp.pseudo.service.sid;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.IdToken;
 import com.google.auth.oauth2.IdTokenProvider;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.filter.ClientFilterChain;
@@ -23,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * uses the Compute metadata server.
  */
 @IdTokenFilterMatcher
+@Requires(notEnv = "k8s")
 @Singleton
 @Slf4j
 public class IdTokenFilter implements HttpClientFilter {


### PR DESCRIPTION
The IdTokenFilter is used only for service-to-service authentication between Cloud Run services. Services in k8s use istio-proxy, so we disable IdTokenFilter in k8s environment.