### PR TITLE
Update PseudoField and PseudonymizeField endpoint to utilize Flowable

### DIFF
--- a/doc/requests/examples-field.http
+++ b/doc/requests/examples-field.http
@@ -32,7 +32,7 @@ Authorization: Bearer {{keycloak_token}}
       "16910599481",
       "03874398925"
     ],
-    "pseudoFunc": "daead(keyId=ssb-common-key-2"
+    "pseudoFunc": "daead(keyId=ssb-common-key-2)"
   }
 }
 

--- a/doc/requests/examples-field.http
+++ b/doc/requests/examples-field.http
@@ -85,6 +85,6 @@ Authorization: Bearer {{keycloak_token}}
       "16910599481",
       "03874398925"
     ],
-    "pseudoFunc": "map-sid(keyId=papis-common-key1)"
+    "pseudoFunc": "map-sid(keyId=papis-key-1)"
   }
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -80,7 +80,7 @@ public class PseudoController {
             log.info(Strings.padEnd(String.format("*** Pseudonymize field: %s ", req.getName()), 80, '*'));
             PseudoField pseudoField = new PseudoField(req.getName(), req.getValues(), req.getPseudoFunc(), req.getKeyset());
 
-            MutableHttpResponse mutableHttpResponse = HttpResponse.ok(pseudoField.process(pseudoConfigSplitter,recordProcessorFactory));
+            MutableHttpResponse mutableHttpResponse = HttpResponse.ok(pseudoField.process(pseudoConfigSplitter, recordProcessorFactory));
 
             // Add metadata to header
             mutableHttpResponse.getHeaders().add("metadata", pseudoField

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -76,14 +76,14 @@ public class PseudoController {
     @Operation(summary = "Pseudonymize field", description = "Pseudonymize a field.")
     @Post("/pseudonymize/field")
     @ExecuteOn(TaskExecutors.IO)
-    public HttpResponse<ResponsePseudoField> pseudonymizeField(@Schema(implementation = PseudoFieldRequest.class) String request) {
+    public HttpResponse<Flowable> pseudonymizeField(@Schema(implementation = PseudoFieldRequest.class) String request) {
         PseudoFieldRequest req = Json.toObject(PseudoFieldRequest.class, request);
 
         log.info("Pseudonymize field  '{}'.",req.getName());
         PseudoField pseudoField = new PseudoField(req.getName(), req.getValues(), req.getPseudoFunc(), req.getKeyset());
 
-        return HttpResponse.ok(pseudoField
-                .pseudonymizeThenGetResponseField(recordProcessorFactory));
+        return HttpResponse.ok(Flowable.just(pseudoField
+                .pseudonymizeThenGetResponseField(recordProcessorFactory)));
     }
 
     @Operation(summary = "Pseudonymize file", description = """
@@ -369,7 +369,7 @@ public class PseudoController {
         private String name;
         private List<String> values;
         private String pseudoFunc;
-        private String stableIDSnapshot;
+        private String stableIdSnapshot;
         private EncryptedKeysetWrapper keyset;
     }
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -2,10 +2,7 @@ package no.ssb.dlp.pseudo.service.pseudo;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.HttpResponse;
-import io.micronaut.http.HttpStatus;
-import io.micronaut.http.MediaType;
+import io.micronaut.http.*;
 import io.micronaut.http.annotation.Error;
 import io.micronaut.http.annotation.*;
 import io.micronaut.http.hateoas.JsonError;
@@ -71,38 +68,51 @@ public class PseudoController {
      * Pseudonymizes a field.
      *
      * @param request JSON string representing a {@link PseudoFieldRequest} object.
-     * @return HTTP response containing a {@link ResponsePseudoField} object.
+     * @return HTTP response containing a {@link HttpResponse<Flowable>} object.
      */
     @Operation(summary = "Pseudonymize field", description = "Pseudonymize a field.")
-    @Post("/pseudonymize/field")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Post(value = "/pseudonymize/field", consumes = MediaType.APPLICATION_JSON)
     @ExecuteOn(TaskExecutors.IO)
     public HttpResponse<Flowable> pseudonymizeField(@Schema(implementation = PseudoFieldRequest.class) String request) {
-        PseudoFieldRequest req = Json.toObject(PseudoFieldRequest.class, request);
+        try {
+            PseudoFieldRequest req = Json.toObject(PseudoFieldRequest.class, request);
+            log.info(Strings.padEnd(String.format("*** Pseudonymize field: %s ", req.getName()), 80, '*'));
+            PseudoField pseudoField = new PseudoField(req.getName(), req.getValues(), req.getPseudoFunc(), req.getKeyset());
 
-        log.info("Pseudonymize field  '{}'.",req.getName());
-        PseudoField pseudoField = new PseudoField(req.getName(), req.getValues(), req.getPseudoFunc(), req.getKeyset());
+            MutableHttpResponse mutableHttpResponse = HttpResponse.ok(pseudoField.process(pseudoConfigSplitter,recordProcessorFactory));
 
-        return HttpResponse.ok(Flowable.just(pseudoField
-                .pseudonymizeThenGetResponseField(recordProcessorFactory)));
+            // Add metadata to header
+            mutableHttpResponse.getHeaders().add("metadata", pseudoField
+                    .getPseudoFieldMetadata()
+                    .toJsonString());
+
+            return mutableHttpResponse;
+
+
+        } catch (Exception e) {
+            return HttpResponse.serverError(Flowable.error(e));
+        }
     }
+
 
     @Operation(summary = "Pseudonymize file", description = """
             Pseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
-            
+                        
             Choose between streaming the pseudonymized result back, or storing it as a file in GCS (by providing a `targetUri`).
-            
+                        
             Notice that you can specify the `targetContentType` if you want to convert to either of the supported file
             formats. E.g. your source could be a CSV file and the result could be a JSON file.
 
             Reduce transmission times by applying compression both to the source and target files.
             Specify `compression` if you want the result to be a zipped (and optionally) encrypted archive.
-            
+                        
             Pseudonymization will be applied according to a list of "rules" that target the fields of the file being
             processed. Each rule defines a `pattern` (according to [glob pattern matching](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob))
             that identifies one or multiple fields, and a `func` that will be applied to the matching fields. Rules are
             processed in the order they are defined, and only the first matching rule will be applied (thus: rule ordering
             is important).
-            
+                        
             Pseudo rules will most times refer to crypto keys. You can provide your own keys to use (via the `keysets` param)
             or use one of the predefined keys: `ssb-common-key-1` or `ssb-common-key-2`.
             """
@@ -140,27 +150,27 @@ public class PseudoController {
     @Operation(
             summary = "Depseudonymize file",
             description = """
-            Depseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
-            
-            Notice that only certain whitelisted users can depseudonymize data.
-            
-            Choose between streaming the result back, or storing it as a file in GCS (by providing a `targetUri`).
-            
-            Notice that you can specify the `targetContentType` if you want to convert to either of the supported file
-            formats. E.g. your source could be a CSV file and the result could be a JSON file.
+                    Depseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
+                                
+                    Notice that only certain whitelisted users can depseudonymize data.
+                                
+                    Choose between streaming the result back, or storing it as a file in GCS (by providing a `targetUri`).
+                                
+                    Notice that you can specify the `targetContentType` if you want to convert to either of the supported file
+                    formats. E.g. your source could be a CSV file and the result could be a JSON file.
 
-            Reduce transmission times by applying compression both to the source and target files.
-            Specify `compression` if you want the result to be a zipped (and optionally) encrypted archive.
-            
-            Depseudonymization will be applied according to a list of "rules" that target the fields of the file being
-            processed. Each rule defines a `pattern` (according to [glob pattern matching](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob))
-            that identifies one or multiple fields, and a `func` that will be applied to the matching fields. Rules are
-            processed in the order they are defined, and only the first matching rule will be applied (thus: rule ordering
-            is important).
-            
-            Pseudo rules will most times refer to crypto keys. You can provide your own keys to use (via the `keysets` param)
-            or use one of the predefined keys: `ssb-common-key-1` or `ssb-common-key-2`.
-            """
+                    Reduce transmission times by applying compression both to the source and target files.
+                    Specify `compression` if you want the result to be a zipped (and optionally) encrypted archive.
+                                
+                    Depseudonymization will be applied according to a list of "rules" that target the fields of the file being
+                    processed. Each rule defines a `pattern` (according to [glob pattern matching](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob))
+                    that identifies one or multiple fields, and a `func` that will be applied to the matching fields. Rules are
+                    processed in the order they are defined, and only the first matching rule will be applied (thus: rule ordering
+                    is important).
+                                
+                    Pseudo rules will most times refer to crypto keys. You can provide your own keys to use (via the `keysets` param)
+                    or use one of the predefined keys: `ssb-common-key-1` or `ssb-common-key-2`.
+                    """
     )
     @Post("/depseudonymize/file")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -199,27 +209,27 @@ public class PseudoController {
     @Operation(
             summary = "Repseudonymize file",
             description = """
-            Repseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
-            Repseudonymization is done by first applying depseudonuymization and then pseudonymization to fields of the file.
-            
-            Choose between streaming the result back, or storing it as a file in GCS (by providing a `targetUri`).
-            
-            Notice that you can specify the `targetContentType` if you want to convert to either of the supported file
-            formats. E.g. your source could be a CSV file and the result could be a JSON file.
+                    Repseudonymize a file (JSON or CSV - or a zip with potentially multiple such files) by uploading the file.
+                    Repseudonymization is done by first applying depseudonuymization and then pseudonymization to fields of the file.
+                                
+                    Choose between streaming the result back, or storing it as a file in GCS (by providing a `targetUri`).
+                                
+                    Notice that you can specify the `targetContentType` if you want to convert to either of the supported file
+                    formats. E.g. your source could be a CSV file and the result could be a JSON file.
 
-            Reduce transmission times by applying compression both to the source and target files.
-            Specify `compression` if you want the result to be a zipped (and optionally) encrypted archive.
-            
-            Repseudonymization will be applied according to a list of "rules" that target the fields of the file being
-            processed. Each rule defines a `pattern` (according to [glob pattern matching](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob))
-            that identifies one or multiple fields, and a `func` that will be applied to the matching fields. Rules are
-            processed in the order they are defined, and only the first matching rule will be applied (thus: rule ordering
-            is important). Two sets of rules are provided: one that defines how to depseudonymize and a second that defines
-            how to pseudonymize. These sets of rules are linked to separate keysets.
-            
-            Pseudo rules will most times refer to crypto keys. You can provide your own keys to use (via the `keysets` param)
-            or use one of the predefined keys: `ssb-common-key-1` or `ssb-common-key-2`.
-            """
+                    Reduce transmission times by applying compression both to the source and target files.
+                    Specify `compression` if you want the result to be a zipped (and optionally) encrypted archive.
+                                
+                    Repseudonymization will be applied according to a list of "rules" that target the fields of the file being
+                    processed. Each rule defines a `pattern` (according to [glob pattern matching](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob))
+                    that identifies one or multiple fields, and a `func` that will be applied to the matching fields. Rules are
+                    processed in the order they are defined, and only the first matching rule will be applied (thus: rule ordering
+                    is important). Two sets of rules are provided: one that defines how to depseudonymize and a second that defines
+                    how to pseudonymize. These sets of rules are linked to separate keysets.
+                                
+                    Pseudo rules will most times refer to crypto keys. You can provide your own keys to use (via the `keysets` param)
+                    or use one of the predefined keys: `ssb-common-key-1` or `ssb-common-key-2`.
+                    """
     )
     @Post("/repseudonymize/file")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -282,8 +292,7 @@ public class PseudoController {
             }
 
             return new ProcessFileResult(targetContentType, res);
-        }
-        finally {
+        } finally {
             try {
                 if (fileSource != null) {
                     fileSource.cleanup();
@@ -291,8 +300,7 @@ public class PseudoController {
                 if (tempFile != null) {
                     Files.deleteIfExists(tempFile.toPath());
                 }
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 log.warn("Error cleaning up", e);
             }
         }
@@ -302,13 +310,13 @@ public class PseudoController {
         if (targetContentType.equals(MediaType.APPLICATION_JSON_TYPE)) {
             AtomicBoolean first = new AtomicBoolean(true);
             return recordStream
-              .map(rec -> {
-                  if (first.getAndSet(false)) {
-                      return "[%s".formatted(rec);
-                  }
-                  return ",%s".formatted(rec);
-              })
-              .concatWith(Single.just("]"));
+                    .map(rec -> {
+                        if (first.getAndSet(false)) {
+                            return "[%s".formatted(rec);
+                        }
+                        return ",%s".formatted(rec);
+                    })
+                    .concatWith(Single.just("]"));
         }
 
         return recordStream;
@@ -323,14 +331,13 @@ public class PseudoController {
         File tempFile = tempDir.resolve(data.getFilename()).toFile();
         log.debug("Receive file - stored temporarily at " + tempFile.getAbsolutePath());
         return Single.fromPublisher(data.transferTo(tempFile))
-          .map(success -> {
-              if (Boolean.TRUE.equals(success)) {
-                  return tempFile;
-              }
-              else {
-                  throw new IOException("Error receiving file " + tempFile);
-              }
-          });
+                .map(success -> {
+                    if (Boolean.TRUE.equals(success)) {
+                        return tempFile;
+                    } else {
+                        throw new IOException("Error receiving file " + tempFile);
+                    }
+                });
     }
 
     @Data
@@ -349,9 +356,11 @@ public class PseudoController {
         @Schema(implementation = String.class)
         private URI targetUri;
 
-        /** The content type of the resulting file. */
+        /**
+         * The content type of the resulting file.
+         */
         @Schema(implementation = String.class, allowableValues = {
-          MediaType.APPLICATION_JSON, MoreMediaTypes.TEXT_CSV})
+                MediaType.APPLICATION_JSON, MoreMediaTypes.TEXT_CSV})
         private MediaType targetContentType;
 
         /**
@@ -366,11 +375,10 @@ public class PseudoController {
         /**
          * The pseudonymization config to apply
          */
+        private String pseudoFunc;
+        private EncryptedKeysetWrapper keyset;
         private String name;
         private List<String> values;
-        private String pseudoFunc;
-        private String stableIdSnapshot;
-        private EncryptedKeysetWrapper keyset;
     }
 
     @Data
@@ -394,7 +402,9 @@ public class PseudoController {
         @Schema(implementation = String.class)
         private URI targetUri;
 
-        /** The content type of the resulting file. */
+        /**
+         * The content type of the resulting file.
+         */
         @Schema(implementation = String.class, allowableValues = {
                 MediaType.APPLICATION_JSON, MoreMediaTypes.TEXT_CSV})
         private MediaType targetContentType;
@@ -416,7 +426,9 @@ public class PseudoController {
     @Data
     public static class TargetCompression {
 
-        /** The password on the resulting archive */
+        /**
+         * The password on the resulting archive
+         */
         @NotBlank
         @Schema(implementation = String.class)
         @Min(9)

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
@@ -1,31 +1,33 @@
 package no.ssb.dlp.pseudo.service.pseudo;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.micronaut.http.MutableHttpHeaders;
+import io.reactivex.Flowable;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
-import lombok.extern.log4j.Log4j2;
-import no.ssb.dlp.pseudo.core.field.FieldDescriptor;
-import no.ssb.dlp.pseudo.core.field.FieldPseudonymizer;
+import lombok.extern.jackson.Jacksonized;
 import no.ssb.dlp.pseudo.core.func.PseudoFuncRule;
+import no.ssb.dlp.pseudo.core.map.RecordMapProcessor;
 import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a field to be pseudonymized.
  */
-@Log4j2
 @Data
 public class PseudoField {
+    @Getter(AccessLevel.PROTECTED)
+    private static final int BUFFER_SIZE = 10000;
     @Getter(AccessLevel.PROTECTED)
     private static final String DEFAULT_PSEUDO_FUNC = "daead(keyId=ssb-common-key-1)";
 
     protected String name;
     protected List<String> values;
     protected PseudoConfig pseudoConfig;
-    private List<String> sidValues;
 
     /**
      * Constructs a {@code PseudoField} object with the specified name, values, keyset, pseudoConfig. If no keyset is supplied
@@ -49,56 +51,54 @@ public class PseudoField {
             pseudoConfig.getKeysets().add(keyset);
         }
         pseudoConfig.getRules().add(new PseudoFuncRule(name, "**", pseudoFunc));
+
     }
 
     /**
-     * Pseudonymizes the field using the provided record processor factory and returns a {@link ResponsePseudoField} object
-     * containing the encrypted values, field name, and pseudo rules.
+     * Creates a Flowable that processes each value of the field, by applying the configured pseudo rules using a recordMapProcessor.
      *
-     * @param recordProcessorFactory The record processor factory used to create a field pseudonymizer.
-     * @return A {@link ResponsePseudoField} object containing the encrypted values, field name, and pseudo rules.
+     * @param pseudoConfigSplitter   The PseudoConfigSplitter instance to use for splitting pseudo configurations.
+     * @param recordProcessorFactory The RecordMapProcessorFactory instance to use for creating a new PseudonymizeRecordProcessor.
+     * @return A Flowable stream that processes the field values by applying the configured pseudo rules, and returns them as a lists of strings.
      */
-    public ResponsePseudoField pseudonymizeThenGetResponseField(RecordMapProcessorFactory recordProcessorFactory) {
-        List<String> encryptedValues = pseudonymize(values, recordProcessorFactory);
-        return this.getResponseField(encryptedValues);
-    }
+    public Flowable<List<String>> process(PseudoConfigSplitter pseudoConfigSplitter, RecordMapProcessorFactory recordProcessorFactory) {
+        List<PseudoConfig> pseudoConfigs = pseudoConfigSplitter.splitIfNecessary(this.getPseudoConfig());
 
+        RecordMapProcessor recordMapProcessor = recordProcessorFactory.newPseudonymizeRecordProcessor(pseudoConfigs);
 
-    protected List<String> pseudonymize(List<String> values, RecordMapProcessorFactory recordProcessorFactory) {
-        Instant startTime = Instant.now();
-
-        FieldPseudonymizer fieldPseudonymizer = recordProcessorFactory.newFieldPseudonymizer(this.getPseudoConfig().getRules(), RecordMapProcessorFactory.pseudoKeysetsOf(this.getPseudoConfig().getKeysets()));
-
-        ArrayList<String> encryptedValues = new ArrayList<>();
-
-        values.stream().map(value -> fieldPseudonymizer.pseudonymize(new FieldDescriptor(this.getName()), value)).forEach(result -> encryptedValues.add(result));
-
-        Instant endTime = Instant.now();
-        Duration duration = Duration.between(startTime, endTime);
-        log.info("Pseudonymizing field '{}' took {} milliseconds.", this.getName(), duration.toMillis());
-
-        return encryptedValues;
+        return Flowable.fromIterable(() -> this.getValues().stream()
+                .map(value -> recordMapProcessor.process(Map.of(this.getName(), value))
+                        .get(this.getName()).toString())
+                .iterator()).buffer(BUFFER_SIZE);
     }
 
 
     /**
-     * Creates a {@link ResponsePseudoField} object with the provided encrypted value.
+     * Creates a {@link PseudoFieldMetadata} object with the metadata about the preformed pseudo operations.
      *
-     * @param encryptedValues The encrypted values of the field.
-     * @return A {@link ResponsePseudoField} object containing the encrypted values, field name, and pseudo rules.
+     * @return A {@link PseudoFieldMetadata} object containing the field name and pseudo rules used.
      */
-    public ResponsePseudoField getResponseField(List<String> encryptedValues) {
-        return ResponsePseudoField.builder()
-                .values(encryptedValues)
+    public PseudoFieldMetadata getPseudoFieldMetadata() {
+        return PseudoFieldMetadata.builder()
                 .fieldName(name)
                 .pseudoRules(pseudoConfig).build();
     }
 }
 
+@Builder
 @Data
-@SuperBuilder
-class ResponsePseudoField {
-    private List<String> values;
+class PseudoFieldMetadata {
     private String fieldName;
     private PseudoConfig pseudoRules;
+
+    public String toJsonString() throws JsonProcessingException {
+        /**
+         * Converts the {@link PseudoFieldMetadata} object to a JSON string.
+         *
+         * @return A {@link String} representing the JSON representation of the PseudoFieldMetadata
+         * @throws JsonProcessingException if an error occurs during JSON processing
+         */
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(this);
+    }
 }

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -1,14 +1,8 @@
 package no.ssb.dlp.pseudo.service.pseudo;
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import no.ssb.dlp.pseudo.core.field.FieldDescriptor;
-import no.ssb.dlp.pseudo.core.field.FieldPseudonymizer;
 import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -39,82 +33,4 @@ class PseudoFieldTest {
         assertEquals(encryptedKeysetWrapper,
                 pseudoField.getPseudoConfig().getKeysets().get(0));
     }
-
-    @Test
-    public void testPseudonymize() {
-        List<String> fieldValues = List.of("1", "2", "3");
-        List<String> expectedEncryptedFieldValues = List.of("encrypted:1", "encrypted:2", "encrypted:3");
-
-        RecordMapProcessorFactory recordProcessorFactory = mock(RecordMapProcessorFactory.class);
-        FieldPseudonymizer fieldPseudonymizer = mock(FieldPseudonymizer.class);
-
-        when(recordProcessorFactory.newFieldPseudonymizer(anyList(), any())).thenReturn(fieldPseudonymizer);
-
-        PseudoField pseudoField = new PseudoField(null, fieldValues, null, null);
-
-        ArrayList<String> encryptedValues = new ArrayList<>();
-        //Calls to fieldPseudonymizer pseudonymize will return "encrypted:" + original string
-        when(fieldPseudonymizer.pseudonymize(any(), anyString()))
-                .thenAnswer(invocation -> {
-                    FieldDescriptor fieldDescriptor = invocation.getArgument(0);
-                    String value = invocation.getArgument(1);
-                    String encryptedValue = "encrypted:" + value;
-                    encryptedValues.add(encryptedValue);
-                    return encryptedValue;
-                });
-
-        assertEquals(expectedEncryptedFieldValues, pseudoField.pseudonymize(fieldValues, recordProcessorFactory));
-    }
-
-    @Test
-    void testPseudonymizeThenGetResponseFieldWithDefaultConfig() {
-        String fieldName = "name";
-        List<String> fieldValues = List.of("1", "2", "3");
-        List<String> expectedEncryptedFieldValues = List.of("encrypted:1", "encrypted:2", "encrypted:3");
-
-        RecordMapProcessorFactory recordProcessorFactory = mock(RecordMapProcessorFactory.class);
-        FieldPseudonymizer fieldPseudonymizer = mock(FieldPseudonymizer.class);
-        when(recordProcessorFactory.newFieldPseudonymizer(anyList(), any())).thenReturn(fieldPseudonymizer);
-
-        PseudoField pseudoField = spy(new PseudoField("name", fieldValues, null, null));
-
-        // Mock away pseudonymize, tested in testPseudonymize
-        when(pseudoField.pseudonymize(fieldValues, recordProcessorFactory)).thenReturn(expectedEncryptedFieldValues);
-
-        ResponsePseudoField responsePseudoField = pseudoField.pseudonymizeThenGetResponseField(recordProcessorFactory);
-
-        //Response should contain the same fieldName
-        assertEquals(fieldName, responsePseudoField.getFieldName());
-        //Response should contain the same pseudoConfig
-        assertEquals(pseudoField.getPseudoConfig(), responsePseudoField.getPseudoRules());
-        //Response encrypted values should be prefixed with "encrypted:"
-        assertEquals(expectedEncryptedFieldValues, responsePseudoField.getValues());
-    }
-
-    @Test
-    public void pseudonymizeTest() {
-        List<String> fieldValues = List.of("1", "2", "3");
-        List<String> expectedEncryptedFieldValues = List.of("encrypted:1", "encrypted:2", "encrypted:3");
-
-        RecordMapProcessorFactory recordProcessorFactory = mock(RecordMapProcessorFactory.class);
-        FieldPseudonymizer fieldPseudonymizer = mock(FieldPseudonymizer.class);
-
-        when(recordProcessorFactory.newFieldPseudonymizer(anyList(), any())).thenReturn(fieldPseudonymizer);
-
-        PseudoField pseudoField = new PseudoField(null, fieldValues, null, null);
-
-        ArrayList<String> encryptedValues = new ArrayList<>();
-        //Calls to fieldPseudonymizer pseudonymize will return "encrypted:" + original string
-        when(fieldPseudonymizer.pseudonymize(any(), anyString()))
-                .thenAnswer(invocation -> {
-                    FieldDescriptor fieldDescriptor = invocation.getArgument(0);
-                    String value = invocation.getArgument(1);
-                    String encryptedValue = "encrypted:" + value;
-                    encryptedValues.add(encryptedValue);
-                    return encryptedValue;
-                });
-
-        assertEquals(expectedEncryptedFieldValues, pseudoField.pseudonymize(fieldValues, recordProcessorFactory));
-    }
-
 }


### PR DESCRIPTION
***Changes:***

- Refactored field processing to utilize streaming for improved efficiency.
- Updated the pseudonymizeField endpoint to utilize the optimized process method of PseudoField.
- Added metadata to the response header.

Additionally, performance benchmarks were conducted using a local Pseudo Service and dapla-toolbelt-pseudo with the "pseudoFunc": "daead(keyId=ssb-common-key-1)" configuration. The results demonstrate a significant increase in performance for both single and multi-column dataframes.

**Benchmark single column dataframe:**
<img width="1685" alt="single field" src="https://github.com/statisticsnorway/dapla-dlp-pseudo-service/assets/8294494/e37d7c7d-0c9c-41ef-94a4-eb36e11cd4d7">


**Benchmark six column dataframe:**
<img width="1680" alt="multifield  6 fields" src="https://github.com/statisticsnorway/dapla-dlp-pseudo-service/assets/8294494/73646724-aea2-46c3-8287-c706e9b365af">
