### PR TITLE
Throw 400 when invalid SID version is supplied in request

### DIFF
--- a/doc/requests/examples-sid.http
+++ b/doc/requests/examples-sid.http
@@ -43,7 +43,7 @@ Content-Type: application/json
       {
         "name": "fnr",
         "pattern": "**/fnr",
-        "func": "map-sid(keyId=papis-key-1,versionTimestamp=2023_04_25-12_35_40_649511)"
+        "func": "map-sid(keyId=papis-key-1,versionTimestamp=2023_04_25-12_35_40_6495)"
       }
     ]
   }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/InvalidSidVersionException.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/InvalidSidVersionException.java
@@ -1,0 +1,7 @@
+package no.ssb.dlp.pseudo.service.sid;
+
+public class InvalidSidVersionException extends RuntimeException {
+    public InvalidSidVersionException(String message) {
+            super(message);
+        }
+}

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
@@ -94,8 +94,11 @@ public class SidMapper implements Mapper {
         if (config.containsKey(MapFuncConfig.Param.VERSION_TIMESTAMP)) {
             VersionInfo snapshots = ObservableSubscriber.subscribe(this.sidService.getSnapshots()).awaitResult()
                     .orElseThrow(() -> new RuntimeException("SID service did not respond"));
-            if (!snapshots.getItems().contains(config.get(MapFuncConfig.Param.VERSION_TIMESTAMP).toString())) {
-                throw new RuntimeException(String.format("Invalid version timestamp. Valid versions are: %s",
+            if (snapshots.getItems() == null)
+                throw new InvalidSidVersionException("Invalid version timestamp. There are no valid versions");
+
+            else if (!snapshots.getItems().contains(config.get(MapFuncConfig.Param.VERSION_TIMESTAMP).toString())) {
+                throw new InvalidSidVersionException(String.format("Invalid version timestamp. Valid versions are: %s",
                         String.join(", ", snapshots.getItems())));
             }
         }


### PR DESCRIPTION
Previously, an internal server error (code 500) was returned when an invalid SID version was encountered
