### PR TITLE
Add support for new timestamp format in SID service

### DIFF
--- a/conf/application-local.yml
+++ b/conf/application-local.yml
@@ -102,4 +102,5 @@ app-roles:
     - kons-skaar@ssb.no
     - kons-lunde@ssb.no
     - mmw@ssb.no
+    - mic@ssb.no
 

--- a/conf/application-sid-client-ext.yml
+++ b/conf/application-sid-client-ext.yml
@@ -1,0 +1,21 @@
+micronaut:
+  netty:
+    event-loops:
+      sid-group:
+        num-threads: 10
+        prefer-native-transport: true
+  http:
+    client:
+      event-loop-group: sid-group
+      read-timeout: 60s
+    services:
+      sid-service:
+        url: 'http://localhost:10240'
+        path: '/v2'
+        read-timeout: 60s
+        event-loop-group: sid-group
+#        pool:
+#          enabled: true
+#          max-connections: 50
+
+sid.mapper.partition.size: 100

--- a/doc/requests/examples-sid.http
+++ b/doc/requests/examples-sid.http
@@ -43,7 +43,7 @@ Content-Type: application/json
       {
         "name": "fnr",
         "pattern": "**/fnr",
-        "func": "map-sid(keyId=papis-key-1)"
+        "func": "map-sid(keyId=papis-key-1,versionTimestamp=2023_04_25-12_35_40_649511)"
       }
     ]
   }

--- a/doc/requests/examples-sid.http
+++ b/doc/requests/examples-sid.http
@@ -43,7 +43,7 @@ Content-Type: application/json
       {
         "name": "fnr",
         "pattern": "**/fnr",
-        "func": "map-sid(keyId=papis-key-1,versionTimestamp=2023-07-05)"
+        "func": "map-sid(keyId=papis-key-1,snapshotDate=2023-07-05)"
       }
     ]
   }

--- a/doc/requests/examples-sid.http
+++ b/doc/requests/examples-sid.http
@@ -43,7 +43,7 @@ Content-Type: application/json
       {
         "name": "fnr",
         "pattern": "**/fnr",
-        "func": "map-sid(keyId=papis-key-1,versionTimestamp=2023_04_25-12_35_40_6495)"
+        "func": "map-sid(keyId=papis-key-1,versionTimestamp=2023-07-05)"
       }
     ]
   }

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>no.ssb.dapla.dlp.pseudo</groupId>
       <artifactId>dapla-dlp-pseudo-core</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.4</version>
     </dependency>
     <dependency>
       <groupId>no.ssb.avro.convert.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.dlp.pseudo.service</groupId>
   <artifactId>dapla-dlp-pseudo-service</artifactId>
-  <version>2.2.6</version>
+  <version>2.2.7-SNAPSHOT</version>
 
   <parent>
     <groupId>io.micronaut</groupId>
@@ -33,7 +33,7 @@
     <connection>scm:git:git://github.com/statisticsnorway/dapla-dlp-pseudo-service.git</connection>
     <developerConnection>scm:git:git@github.com:statisticsnorway/dapla-dlp-pseudo-service.git</developerConnection>
     <url>https://github.com/statisticsnorway/dapla-dlp-pseudo-service</url>
-    <tag>2.2.6</tag>
+    <tag>2.2.3</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.dlp.pseudo.service</groupId>
   <artifactId>dapla-dlp-pseudo-service</artifactId>
-  <version>2.2.6-SNAPSHOT</version>
+  <version>2.2.6</version>
 
   <parent>
     <groupId>io.micronaut</groupId>
@@ -33,7 +33,7 @@
     <connection>scm:git:git://github.com/statisticsnorway/dapla-dlp-pseudo-service.git</connection>
     <developerConnection>scm:git:git@github.com:statisticsnorway/dapla-dlp-pseudo-service.git</developerConnection>
     <url>https://github.com/statisticsnorway/dapla-dlp-pseudo-service</url>
-    <tag>2.2.3</tag>
+    <tag>2.2.6</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.ssb.dlp.pseudo.service</groupId>
   <artifactId>dapla-dlp-pseudo-service</artifactId>
-  <version>2.2.5</version>
+  <version>2.2.6-SNAPSHOT</version>
 
   <parent>
     <groupId>io.micronaut</groupId>
@@ -33,7 +33,7 @@
     <connection>scm:git:git://github.com/statisticsnorway/dapla-dlp-pseudo-service.git</connection>
     <developerConnection>scm:git:git@github.com:statisticsnorway/dapla-dlp-pseudo-service.git</developerConnection>
     <url>https://github.com/statisticsnorway/dapla-dlp-pseudo-service</url>
-    <tag>2.2.5</tag>
+    <tag>2.2.3</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>no.ssb.dapla.dlp.pseudo</groupId>
       <artifactId>dapla-dlp-pseudo-core</artifactId>
-      <version>1.2.4</version>
+      <version>1.2.5</version>
     </dependency>
     <dependency>
       <groupId>no.ssb.avro.convert.core</groupId>

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
@@ -39,7 +39,7 @@ public class ExternalSidService implements SidService {
     }
 
     @Override
-    public Publisher<VersionInfo> getSnapshots() {
+    public Publisher<SnapshotInfo> getSnapshots() {
         return sidClient.snapshots();
     }
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
@@ -38,4 +38,8 @@ public class ExternalSidService implements SidService {
         );
     }
 
+    @Override
+    public Publisher<VersionInfo> getSnapshots() {
+        return sidClient.snapshots();
+    }
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -52,6 +52,10 @@ class LocalSidService implements SidService {
         );
     }
 
+    @Override
+    public Publisher<VersionInfo> getSnapshots() {
+        return Publishers.just(VersionInfo.builder().build());
+    }
 
     public static class NoSidMappingFoundException extends RuntimeException {
         public NoSidMappingFoundException(String message) {

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -54,7 +54,7 @@ class LocalSidService implements SidService {
 
     @Override
     public Publisher<VersionInfo> getSnapshots() {
-        return Publishers.just(VersionInfo.builder().items(List.of("2023_04_25-12_35_40_6495")).build());
+        return Publishers.just(VersionInfo.builder().items(List.of("2023-04-25")).build());
     }
 
     public static class NoSidMappingFoundException extends RuntimeException {

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -53,8 +53,8 @@ class LocalSidService implements SidService {
     }
 
     @Override
-    public Publisher<VersionInfo> getSnapshots() {
-        return Publishers.just(VersionInfo.builder().items(List.of("2023-04-25")).build());
+    public Publisher<SnapshotInfo> getSnapshots() {
+        return Publishers.just(SnapshotInfo.builder().items(List.of("2023-04-25")).build());
     }
 
     public static class NoSidMappingFoundException extends RuntimeException {

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -54,7 +54,7 @@ class LocalSidService implements SidService {
 
     @Override
     public Publisher<VersionInfo> getSnapshots() {
-        return Publishers.just(VersionInfo.builder().build());
+        return Publishers.just(VersionInfo.builder().items(List.of("2023_04_25-12_35_40_6495")).build());
     }
 
     public static class NoSidMappingFoundException extends RuntimeException {

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidClient.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidClient.java
@@ -1,13 +1,12 @@
 package no.ssb.dlp.pseudo.service.sid;
 
 import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 import org.reactivestreams.Publisher;
-
-import java.util.Map;
 
 @Client(id="sid-service")
 @IdTokenFilterMatcher()
@@ -20,5 +19,9 @@ public interface SidClient {
     @Post( "/sid/map/batch")
     @ExecuteOn(TaskExecutors.IO)
     Publisher<MultiSidResponse> lookup(@Body MultiSidRequest multiSidRequest);
+
+    @Get( "/sid/snapshots")
+    @ExecuteOn(TaskExecutors.IO)
+    Publisher<VersionInfo> snapshots();
 
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidClient.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidClient.java
@@ -22,6 +22,6 @@ public interface SidClient {
 
     @Get( "/sid/snapshots")
     @ExecuteOn(TaskExecutors.IO)
-    Publisher<VersionInfo> snapshots();
+    Publisher<SnapshotInfo> snapshots();
 
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
@@ -93,21 +93,21 @@ public class SidMapper implements Mapper {
 
     private Optional<String> getSnapshot() {
         return Optional.ofNullable(
-                this.config.getOrDefault(MapFuncConfig.Param.VERSION_TIMESTAMP, null)
+                this.config.getOrDefault(MapFuncConfig.Param.SNAPSHOT_DATE, null)
         ).map(String::valueOf);
 
     }
 
     @Override
     public void setConfig(Map<String, Object> config) {
-        if (config.containsKey(MapFuncConfig.Param.VERSION_TIMESTAMP)) {
-            VersionInfo availableSnapshots = ObservableSubscriber.subscribe(this.sidService.getSnapshots()).awaitResult()
+        if (config.containsKey(MapFuncConfig.Param.SNAPSHOT_DATE)) {
+            SnapshotInfo availableSnapshots = ObservableSubscriber.subscribe(this.sidService.getSnapshots()).awaitResult()
                     .orElseThrow(() -> new RuntimeException("SID service did not respond"));
             DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
             LocalDate requestedSnapshotDate;
             try { // Convert the SID snapshot in the request to Date format
                 requestedSnapshotDate = LocalDate.from(formatter.
-                        parse(config.get(MapFuncConfig.Param.VERSION_TIMESTAMP).toString()));
+                        parse(config.get(MapFuncConfig.Param.SNAPSHOT_DATE).toString()));
             } catch (DateTimeParseException e) {
                 throw new RuntimeException(String.format("Invalid version timestamp format. Valid versions are: %s",
                         String.join(", ", availableSnapshots.getItems())));

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
@@ -63,7 +63,8 @@ public class SidMapper implements Mapper {
                     log.info("Execute SID-mapping bulk request");
                     final ObservableSubscriber<Map<String, SidInfo>> subscriber = ObservableSubscriber.subscribe(
                             sidService.lookupFnr(bulkFnr, Optional.ofNullable(
-                                    String.valueOf(this.config.getOrDefault(MapFuncConfig.Param.VERSION_TIMESTAMP, null)))));
+                                    this.config.get(MapFuncConfig.Param.VERSION_TIMESTAMP))
+                                    .map(Object::toString)));
                     for (String f: bulkFnr) {
                         bulkRequest.put(f, subscriber);
                     }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidService.java
@@ -11,4 +11,6 @@ public interface SidService {
 
     Publisher<SidInfo> lookupSnr(String fnr, Optional<String> snapshot);
     Publisher<Map<String, SidInfo>> lookupFnr(List<String> fnrList, Optional<String> snapshot);
+
+    Publisher<VersionInfo> getSnapshots();
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidService.java
@@ -12,5 +12,5 @@ public interface SidService {
     Publisher<SidInfo> lookupSnr(String fnr, Optional<String> snapshot);
     Publisher<Map<String, SidInfo>> lookupFnr(List<String> fnrList, Optional<String> snapshot);
 
-    Publisher<VersionInfo> getSnapshots();
+    Publisher<SnapshotInfo> getSnapshots();
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SnapshotInfo.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SnapshotInfo.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Data
 @Builder
 @Jacksonized
-public class VersionInfo {
+public class SnapshotInfo {
     private final List<String> items;
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/VersionInfo.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/VersionInfo.java
@@ -1,0 +1,14 @@
+package no.ssb.dlp.pseudo.service.sid;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+@Data
+@Builder
+@Jacksonized
+public class VersionInfo {
+    private final List<String> items;
+}

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
@@ -7,10 +7,13 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import no.ssb.dapla.dlp.pseudo.func.map.Mapper;
 import no.ssb.dlp.pseudo.service.Application;
 import org.apache.groovy.util.Maps;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
@@ -42,6 +45,42 @@ public class SidMapperTest {
             Object mappedSid = mapper.map("11854898347");
             verify(sidService, times(1)).lookupFnr(anyList(), any(Optional.class));
             Assertions.assertEquals("0001ha3", mappedSid);
+        }
+    }
+
+    @Test
+    public void testMapValidVersion() {
+        when(sidService.lookupFnr(anyList(), any(Optional.class))).thenReturn(Publishers.just(
+                Maps.of("11854898347", new SidInfo.SidInfoBuilder().snr("0001ha3").build()))
+        );
+        when(sidService.getSnapshots()).thenReturn(Publishers.just(
+                VersionInfo.builder().items(List.of("12345")).build()
+        ));
+        try (var application = mockStatic(Application.class)) {
+            application.when(Application::getContext).thenReturn(context);
+            Mapper mapper = ServiceLoader.load(Mapper.class).findFirst().orElseThrow(() ->
+                    new RuntimeException("SidMapper class not found"));
+            mapper.setConfig(Map.of("versionTimestamp", "12345"));
+            mapper.init("11854898347");
+            Object mappedSid = mapper.map("11854898347");
+            verify(sidService, times(1)).getSnapshots();
+            verify(sidService, times(1)).lookupFnr(anyList(), any(Optional.class));
+            Assertions.assertEquals("0001ha3", mappedSid);
+        }
+    }
+    @Test
+    public void testMapInvValidVersion() {
+        when(sidService.getSnapshots()).thenReturn(Publishers.just(
+                VersionInfo.builder().items(List.of("12345")).build()
+        ));
+        try (var application = mockStatic(Application.class)) {
+            application.when(Application::getContext).thenReturn(context);
+            Mapper mapper = ServiceLoader.load(Mapper.class).findFirst().orElseThrow(() ->
+                    new RuntimeException("SidMapper class not found"));
+            Exception exception = Assert.assertThrows(RuntimeException.class, () -> {
+                mapper.setConfig(Map.of("versionTimestamp", "1234567"));
+            });
+            Assertions.assertEquals("Invalid version timestamp. Valid versions are: 12345", exception.getMessage());
         }
     }
 

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-import javax.swing.text.html.Option;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,13 +56,13 @@ public class SidMapperTest {
                 Maps.of("11854898347", new SidInfo.SidInfoBuilder().snr("0001ha3").build()))
         );
         when(sidService.getSnapshots()).thenReturn(Publishers.just(
-                VersionInfo.builder().items(List.of("2023-04-25")).build()
+                SnapshotInfo.builder().items(List.of("2023-04-25")).build()
         ));
         try (var application = mockStatic(Application.class)) {
             application.when(Application::getContext).thenReturn(context);
             Mapper mapper = ServiceLoader.load(Mapper.class).findFirst().orElseThrow(() ->
                     new RuntimeException("SidMapper class not found"));
-            mapper.setConfig(Map.of("versionTimestamp", "2023-04-25"));
+            mapper.setConfig(Map.of("snapshotDate", "2023-04-25"));
             mapper.init("11854898347");
             Object mappedSid = mapper.map("11854898347");
             verify(sidService, times(1)).getSnapshots();
@@ -74,14 +73,14 @@ public class SidMapperTest {
     @Test
     public void testMapVersionEarlierThanAvailable() {
         when(sidService.getSnapshots()).thenReturn(Publishers.just(
-                VersionInfo.builder().items(List.of("2023-04-25")).build()
+                SnapshotInfo.builder().items(List.of("2023-04-25")).build()
         ));
         try (var application = mockStatic(Application.class)) {
             application.when(Application::getContext).thenReturn(context);
             Mapper mapper = ServiceLoader.load(Mapper.class).findFirst().orElseThrow(() ->
                     new RuntimeException("SidMapper class not found"));
             Exception exception = Assert.assertThrows(RuntimeException.class, () -> {
-                mapper.setConfig(Map.of("versionTimestamp", "2005-02-27"));
+                mapper.setConfig(Map.of("snapshotDate", "2005-02-27"));
             });
             Assertions.assertEquals("Requested version is of an earlier date than all available SID versions. Valid versions are: 2023-04-25", exception.getMessage());
         }
@@ -90,14 +89,14 @@ public class SidMapperTest {
     @Test
     public void testMapVersionInvalidFormat() {
         when(sidService.getSnapshots()).thenReturn(Publishers.just(
-                VersionInfo.builder().items(List.of("2023-04-25")).build()
+                SnapshotInfo.builder().items(List.of("2023-04-25")).build()
         ));
         try (var application = mockStatic(Application.class)) {
             application.when(Application::getContext).thenReturn(context);
             Mapper mapper = ServiceLoader.load(Mapper.class).findFirst().orElseThrow(() ->
                     new RuntimeException("SidMapper class not found"));
             Exception exception = Assert.assertThrows(RuntimeException.class, () -> {
-                mapper.setConfig(Map.of("versionTimestamp", "25-04-2023"));
+                mapper.setConfig(Map.of("snapshotDate", "25-04-2023"));
             });
             Assertions.assertEquals("Invalid version timestamp format. Valid versions are: 2023-04-25", exception.getMessage());
         }

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
@@ -67,7 +67,7 @@ public class SidMapperTest {
             mapper.init("11854898347");
             Object mappedSid = mapper.map("11854898347");
             verify(sidService, times(1)).getSnapshots();
-            verify(sidService, times(1)).lookupFnr(anyList(), eq(Optional.of("12345")));
+            verify(sidService, times(1)).lookupFnr(anyList(), eq(Optional.of("2023-04-25")));
             Assertions.assertEquals("0001ha3", mappedSid);
         }
     }


### PR DESCRIPTION
This change adds support for specifying the version timestamp according to the new SID format (YYYY-MM-DD)