### PR TITLE
Upgrade Ubuntu in Dockerfile to fix vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM azul/zulu-openjdk:17
-RUN apt-get -qq update && apt-get -y --no-install-recommends install curl
+RUN apt-get -qq update && apt-get -y dist-upgrade && apt-get -y --no-install-recommends install curl
 COPY target/dapla-dlp-pseudo-service-*.jar dapla-dlp-pseudo-service.jar
 COPY target/classes/logback*.xml /conf/
 COPY conf/bootstrap.yml /conf/


### PR DESCRIPTION
There has been exposed a vulnerability in the `glibc` package that stops the newest build from completing. The vulnerability is found in the docker image, so this is an attempt to run `dist-upgrade` with `apt` in order to update `glibc`