### PR TITLE
Add new user role for authenticated users.

### DIFF
--- a/conf/application-local.yml
+++ b/conf/application-local.yml
@@ -97,6 +97,8 @@ pseudo.secrets:
     type: TINK_WDEK
 
 app-roles:
+  users:
+    - isAuthenticated()
   admins:
     - kons_schu@ssb.no
     - kons-skaar@ssb.no

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -44,12 +44,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Principal;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static no.ssb.dlp.pseudo.core.util.Zips.ZipOptions.zipOpts;
@@ -57,7 +55,7 @@ import static no.ssb.dlp.pseudo.core.util.Zips.ZipOptions.zipOpts;
 @RequiredArgsConstructor
 @Controller
 @Slf4j
-@Secured(SecurityRule.IS_AUTHENTICATED)
+@Secured({PseudoServiceRole.USER, PseudoServiceRole.ADMIN})
 @Tag(name = "Pseudo operations")
 public class PseudoController {
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
@@ -32,7 +32,8 @@ public class CustomRolesFinder implements RolesFinder {
         List<String> roles = new ArrayList<>();
 
         Object username = attributes.get(tokenConfiguration.getNameKey());
-        if (rolesConfig.getAdmins().contains(username)) {
+        if (rolesConfig.getAdmins().contains(SecurityRule.IS_AUTHENTICATED)
+                ||rolesConfig.getAdmins().contains(username)) {
             roles.add(PseudoServiceRole.ADMIN);
         }
         if (rolesConfig.getUsers().contains(SecurityRule.IS_AUTHENTICATED)

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requirements;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
+import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.security.token.DefaultRolesFinder;
 import io.micronaut.security.token.RolesFinder;
 import io.micronaut.security.token.config.TokenConfiguration;
@@ -33,6 +34,10 @@ public class CustomRolesFinder implements RolesFinder {
         Object username = attributes.get(tokenConfiguration.getNameKey());
         if (rolesConfig.getAdmins().contains(username)) {
             roles.add(PseudoServiceRole.ADMIN);
+        }
+        if (rolesConfig.getUsers().contains(SecurityRule.IS_AUTHENTICATED)
+                || rolesConfig.getUsers().contains(username)) {
+            roles.add(PseudoServiceRole.USER);
         }
 
         return roles;

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/PseudoServiceRole.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/PseudoServiceRole.java
@@ -4,4 +4,5 @@ public final class PseudoServiceRole {
     private PseudoServiceRole() {}
 
     public static final String ADMIN = "admin";
+    public static final String USER = "user";
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
@@ -11,5 +11,6 @@ import java.util.List;
 @Data
 public class StaticRolesConfig {
     @NotBlank
+    private List<String> users = new ArrayList<>();
     private List<String> admins = new ArrayList<>();
 }


### PR DESCRIPTION
This PR adds a `user` role in addition to the `admin` role. Also use the `isAuthenticated()` keyword to add all authenticated users to a given role.

This enables access control to all the endpoints with environment specific configurations.

Internal ticket ID: DPSTAT-723