### PR TITLE
Add 'keycloak_token' field in README

### DIFF
--- a/doc/requests/README.md
+++ b/doc/requests/README.md
@@ -12,6 +12,7 @@ the following structure:
 {
   "local": {
     "base_url": "localhost:10210",
+    "keycloak_token": "..."
   },
   "staging": {
     "base_url": "localhost:10210",


### PR DESCRIPTION
The 'keycloak_token' field is required even when running the Pseudo Service locally, so we should include a stub in the docs/requests/README.md
