### PR TITLE
PseudoController now correctly returns a JSON object with correct content-type and encoding

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
@@ -119,8 +119,9 @@ public class RecordMapProcessorFactory {
                 PseudoFuncDeclaration funcDeclaration = PseudoFuncDeclaration.fromString(match.getRule().getFunc());
                 final boolean isSidMapping = funcDeclaration.getFuncName().equals(PseudoFuncNames.MAP_SID);
                 final String sidSnapshotDate = output.getMetadata().getOrDefault(MapFuncConfig.Param.SNAPSHOT_DATE, null);
-                if (isSidMapping && sidSnapshotDate == null) {
-                    // Unsuccessful SID-mapping do not have any sidSnapshotDate
+                final String mappedValue = (String) output.getFirstValue();
+                if (isSidMapping && varValue.equals(mappedValue)) {
+                    // Unsuccessful SID-mapping
                     metadataProcessor.addMetric(FieldMetric.MISSING_SID);
                 } else if (isSidMapping) {
                     metadataProcessor.addMetric(FieldMetric.MAPPED_SID);
@@ -143,10 +144,11 @@ public class RecordMapProcessorFactory {
                             .build());
                 }
                 output.getWarnings().forEach(metadataProcessor::addLog);
+                return mappedValue;
             } else {
                 output = match.getFunc().restore(PseudoFuncInput.of(varValue));
+                return (String) output.getFirstValue();
             }
-            return (String) output.getFirstValue();
         } catch (Exception e) {
             throw new PseudoException(String.format("pseudonymize error - field='%s', originalValue='%s'",
                     field.getPath(), varValue), e);

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
@@ -5,7 +5,6 @@ import io.reactivex.Flowable;
 import no.ssb.dlp.pseudo.core.PseudoOperation;
 import no.ssb.dlp.pseudo.core.map.RecordMapProcessor;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata;
-import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetric;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.PseudoMetadataProcessor;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -54,7 +53,6 @@ class DepseudoFieldTest {
                 .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
             .build());
         processor.addLog("Log line");
-        processor.addMetric(FieldMetric.MISSING_SID);
         return processor;
     }
 
@@ -101,7 +99,7 @@ class DepseudoFieldTest {
                       },
                       "metrics": [
                           {
-                            "MISSING_SID": 1
+                            "NULL_VALUE": 1
                           }
                       ],
                       "logs": [

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -84,11 +84,6 @@ class PseudoFieldTest {
                 .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
                 .build());
         processor.addLog("Log line");
-        processor.addMetric(FieldMetric.NULL_VALUE);
-        processor.addMetric(FieldMetric.MISSING_SID);
-        processor.addMetric(FieldMetric.NULL_VALUE);
-        processor.addMetric(FieldMetric.NULL_VALUE);
-        processor.addMetric(FieldMetric.MISSING_SID);
         return processor;
     }
 
@@ -135,10 +130,7 @@ class PseudoFieldTest {
                    },
                    "metrics": [
                      {
-                       "MISSING_SID": 2
-                     },
-                     {
-                       "NULL_VALUE": 3
+                       "NULL_VALUE": 1
                      }
                    ],
                    "logs": [

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
@@ -53,7 +53,6 @@ class RepseudoFieldTest {
                 .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
                 .build());
         processor.addLog("Log line");
-        processor.addMetric(FieldMetric.MISSING_SID);
         return processor;
     }
     @Test
@@ -100,7 +99,7 @@ class RepseudoFieldTest {
                       },
                       "metrics": [
                           {
-                            "MISSING_SID": 1
+                            "NULL_VALUE": 1
                           }
                       ],
                       "logs": [


### PR DESCRIPTION
Micronaut attemps to wrap the `HttpResponse<Publisher<String>>` into a JSON array - which is not correct. According to the docs one can avoid this by returning `HttpResponse<Flowable<byte[]>>` instead.

Also fixed missing `NULL_VALUE` metric in PseudoField and don't rely on missing `sidSnapshotDate` when setting `MISSING_SID` metric.

This fixed the internal ticket ID: DPSTAT-839