### PR TITLE
[DPSTAT-837] Upgrade micronaut to verison 4.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dapla-datadoc-model.version>1.2</dapla-datadoc-model.version>
 
     <artifactregistry-maven-wagon.version>2.2.1</artifactregistry-maven-wagon.version>
-    <dapla-dlp-pseudo-core.version>2.0.1</dapla-dlp-pseudo-core.version>
+    <dapla-dlp-pseudo-core.version>2.0.3</dapla-dlp-pseudo-core.version>
     <micronaut.version>4.3.7</micronaut.version>
     <micronaut.openapi.version>5.0.1</micronaut.openapi.version>
     <micronaut.object.storage.version>2.3.0</micronaut.object.storage.version>
@@ -182,6 +182,11 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.16.1</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>io.micronaut.platform</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.2</version>
   </parent>
 
   <properties>
@@ -25,10 +25,11 @@
 
     <artifactregistry-maven-wagon.version>2.2.1</artifactregistry-maven-wagon.version>
     <dapla-dlp-pseudo-core.version>2.0.1</dapla-dlp-pseudo-core.version>
-    <micronaut.version>4.3.0</micronaut.version>
-    <micronaut.openapi.version>4.6.0</micronaut.openapi.version>
-    <micronaut.object.storage.version>1.1.0</micronaut.object.storage.version>
-    <auto-service.version>1.0.1</auto-service.version>
+    <micronaut.version>4.3.7</micronaut.version>
+    <micronaut.openapi.version>5.0.1</micronaut.openapi.version>
+    <micronaut.object.storage.version>2.3.0</micronaut.object.storage.version>
+    <micronaut.validation.version>4.4.0</micronaut.validation.version>
+    <auto-service.version>1.1.1</auto-service.version>
     <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
@@ -85,11 +86,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-jackson-databind</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>io.micronaut.serde</groupId>
       <artifactId>micronaut-serde-jackson</artifactId>
       <scope>compile</scope>
@@ -122,6 +118,12 @@
     <dependency>
       <groupId>io.micronaut.gcp</groupId>
       <artifactId>micronaut-gcp-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-context</artifactId>
+      <version>${micronaut.version}</version>
     </dependency>
     <dependency>
       <groupId>io.micronaut.objectstorage</groupId>
@@ -184,6 +186,7 @@
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -285,7 +288,7 @@
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
             <release>${jdk.version}</release>
-            <annotationProcessorPaths>
+            <annotationProcessorPaths combine.self="override">
               <path>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
@@ -294,17 +297,50 @@
               <path>
                 <groupId>io.micronaut</groupId>
                 <artifactId>micronaut-inject-java</artifactId>
-                <version>${micronaut.version}</version>
+                <version>${micronaut.core.version}</version>
               </path>
               <path>
-                <groupId>io.micronaut.validation</groupId>
-                <artifactId>micronaut-validation</artifactId>
-                <version>${micronaut.version}</version>
+                <groupId>io.micronaut</groupId>
+                <artifactId>micronaut-graal</artifactId>
+                <version>${micronaut.core.version}</version>
+              </path>
+              <path>
+                <groupId>io.micronaut</groupId>
+                <artifactId>micronaut-http-validation</artifactId>
+                <version>${micronaut.core.version}</version>
               </path>
               <path>
                 <groupId>io.micronaut.security</groupId>
                 <artifactId>micronaut-security-annotations</artifactId>
                 <version>${micronaut.security.version}</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-inject</artifactId>
+                  </exclusion>
+                </exclusions>
+              </path>
+              <path>
+                <groupId>io.micronaut.serde</groupId>
+                <artifactId>micronaut-serde-processor</artifactId>
+                <version>${micronaut.serialization.version}</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-inject</artifactId>
+                  </exclusion>
+                </exclusions>
+              </path>
+              <path>
+                <groupId>io.micronaut.validation</groupId>
+                <artifactId>micronaut-validation-processor</artifactId>
+                <version>${micronaut.validation.version}</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-inject</artifactId>
+                  </exclusion>
+                </exclusions>
               </path>
               <path>
                 <groupId>io.micronaut.openapi</groupId>
@@ -334,12 +370,12 @@
                   <path>
                     <groupId>io.micronaut</groupId>
                     <artifactId>micronaut-inject-java</artifactId>
-                    <version>${micronaut.version}</version>
+                    <version>${micronaut.core.version}</version>
                   </path>
                   <path>
                     <groupId>io.micronaut.validation</groupId>
                     <artifactId>micronaut-validation</artifactId>
-                    <version>${micronaut.version}</version>
+                    <version>${micronaut.validation.version}</version>
                   </path>
                   <path>
                     <groupId>io.micronaut.security</groupId>
@@ -400,7 +436,7 @@
       <plugin>
         <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin</artifactId>
-        <version>${micronaut.version}</version>
+        <version>4.4.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
   <name>dapla-dlp-pseudo-service</name>
 
   <parent>
-    <groupId>io.micronaut</groupId>
+    <groupId>io.micronaut.platform</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>3.9.4</version>
+    <version>4.3.0</version>
   </parent>
 
   <properties>
@@ -25,7 +25,7 @@
 
     <artifactregistry-maven-wagon.version>2.2.1</artifactregistry-maven-wagon.version>
     <dapla-dlp-pseudo-core.version>2.0.1</dapla-dlp-pseudo-core.version>
-    <micronaut.version>3.9.4</micronaut.version>
+    <micronaut.version>4.3.0</micronaut.version>
     <micronaut.openapi.version>4.6.0</micronaut.openapi.version>
     <micronaut.object.storage.version>1.1.0</micronaut.object.storage.version>
     <auto-service.version>1.0.1</auto-service.version>
@@ -76,11 +76,6 @@
     </dependency>
     <dependency>
       <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-validation</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.micronaut</groupId>
       <artifactId>micronaut-http-server-netty</artifactId>
       <scope>compile</scope>
     </dependency>
@@ -90,23 +85,23 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.serde</groupId>
+      <artifactId>micronaut-serde-jackson</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>no.ssb.dapla.metadata</groupId>
       <artifactId>datadoc-model</artifactId>
       <version>${dapla-datadoc-model.version}</version>
     </dependency>
     <dependency>
       <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-runtime</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.micronaut</groupId>
       <artifactId>micronaut-management</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -146,9 +141,9 @@
       <version>${dapla-dlp-pseudo-core.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -162,7 +157,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-     <groupId>com.google.guava</groupId>
+      <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>32.0.0-jre</version>
     </dependency>
@@ -179,6 +174,11 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -297,7 +297,7 @@
                 <version>${micronaut.version}</version>
               </path>
               <path>
-                <groupId>io.micronaut</groupId>
+                <groupId>io.micronaut.validation</groupId>
                 <artifactId>micronaut-validation</artifactId>
                 <version>${micronaut.version}</version>
               </path>
@@ -337,7 +337,7 @@
                     <version>${micronaut.version}</version>
                   </path>
                   <path>
-                    <groupId>io.micronaut</groupId>
+                    <groupId>io.micronaut.validation</groupId>
                     <artifactId>micronaut-validation</artifactId>
                     <version>${micronaut.version}</version>
                   </path>
@@ -398,9 +398,9 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>io.micronaut.build</groupId>
+        <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>${micronaut.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/no/ssb/dlp/pseudo/service/Application.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/Application.java
@@ -41,7 +41,6 @@ public class Application {
 
     public static void main(String[] args) {
         log.info("pseudo-service version: {}", BuildInfo.INSTANCE.getVersionAndBuildTimestamp());
-        context = Micronaut.run(Application.class);
+        context = Micronaut.run(Application.class, args);
     }
-
 }

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityClient.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityClient.java
@@ -4,10 +4,9 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
+import jakarta.annotation.Nullable;
 import no.ssb.dlp.pseudo.service.filters.AccessTokenFilterMatcher;
 import org.reactivestreams.Publisher;
-
-import javax.annotation.Nullable;
 
 @Client(id="cloud-identity-service")
 @AccessTokenFilterMatcher()

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityService.java
@@ -9,12 +9,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Singleton
-// @RequiredArgsConstructor
+@RequiredArgsConstructor
 public class CloudIdentityService {
     private final CloudIdentityClient cloudIdentityClient;
-    public CloudIdentityService(CloudIdentityClient cic){
-        this.cloudIdentityClient = cic;
-    }
 
     @Cacheable(value = "cloud-identity-service-cache", parameters = {"groupEmail"})
     public List<Membership> listMembers(String groupEmail) {

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityService.java
@@ -2,16 +2,19 @@ package no.ssb.dlp.pseudo.service.accessgroups;
 
 import io.micronaut.cache.annotation.Cacheable;
 import io.reactivex.Flowable;
+import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 
-import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 
 @Singleton
-@RequiredArgsConstructor
+// @RequiredArgsConstructor
 public class CloudIdentityService {
     private final CloudIdentityClient cloudIdentityClient;
+    public CloudIdentityService(CloudIdentityClient cic){
+        this.cloudIdentityClient = cic;
+    }
 
     @Cacheable(value = "cloud-identity-service-cache", parameters = {"groupEmail"})
     public List<Membership> listMembers(String groupEmail) {

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/EntityKey.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/EntityKey.java
@@ -1,7 +1,8 @@
 package no.ssb.dlp.pseudo.service.accessgroups;
 
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
 /**
@@ -9,10 +10,8 @@ import lombok.extern.jackson.Jacksonized;
  * An entity can represent either a group with an optional namespace or a user without a namespace. The combination of
  * id and namespace must be unique; however, the same id can be used with different namespaces.
  */
-@Data
 @Builder
 @Jacksonized
-public class EntityKey {
-    private final String id;
-    private final String namespace;
-}
+@Introspected
+@Serdeable.Deserializable
+public record EntityKey(String id, String namespace) {}

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/LookupResponse.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/LookupResponse.java
@@ -1,16 +1,15 @@
 package no.ssb.dlp.pseudo.service.accessgroups;
 
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
-@Data
 @Builder
 @Jacksonized
-public class LookupResponse {
-    // The resource name of the looked-up Group.
-    private final String name;
-
+@Introspected
+@Serdeable.Deserializable
+public record LookupResponse(/* The resource name of the looked-up Group. */ String name) {
     public String getGroupName() {
         return name != null ? name.substring(name.lastIndexOf('/') + 1) : null;
     }

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/Membership.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/Membership.java
@@ -1,5 +1,7 @@
 package no.ssb.dlp.pseudo.service.accessgroups;
 
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
@@ -8,10 +10,8 @@ import lombok.extern.jackson.Jacksonized;
  * A membership within the Cloud Identity Groups API.
  * A Membership defines a relationship between a Group and an entity belonging to that Group, referred to as a "member".
  */
-@Data
 @Builder
 @Jacksonized
-public class Membership {
-    private final String name;
-    private final EntityKey preferredMemberKey;
-}
+@Introspected
+@Serdeable.Deserializable
+public record Membership (String name, EntityKey preferredMemberKey) {}

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/Membership.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/Membership.java
@@ -3,7 +3,6 @@ package no.ssb.dlp.pseudo.service.accessgroups;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
 /**

--- a/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/MembershipResponse.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/accessgroups/MembershipResponse.java
@@ -1,5 +1,7 @@
 package no.ssb.dlp.pseudo.service.accessgroups;
 
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
@@ -9,6 +11,8 @@ import java.util.List;
 @Data
 @Builder
 @Jacksonized
+@Introspected
+@Serdeable.Deserializable
 public class MembershipResponse {
     private final List<Membership> memberships;
     private final String nextPageToken;

--- a/src/main/java/no/ssb/dlp/pseudo/service/filters/AccessTokenFilter.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/filters/AccessTokenFilter.java
@@ -9,14 +9,14 @@ import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.annotation.Nullable;
 import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import java.io.FileInputStream;
 import java.net.URI;
 import java.util.Optional;

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyController.java
@@ -18,8 +18,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.security.Principal;
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/keys/KeyService.java
@@ -6,7 +6,7 @@ import no.ssb.dlp.pseudo.core.util.Json;
 import no.ssb.dlp.pseudo.core.util.TinkUtil;
 import no.ssb.dlp.pseudo.service.tink.KmsConfig;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.net.URI;
 
 @Singleton

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoConfigSplitter.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoConfigSplitter.java
@@ -5,7 +5,7 @@ import no.ssb.dapla.dlp.pseudo.func.tink.fpe.TinkFpeFuncConfig;
 import no.ssb.dlp.pseudo.core.func.PseudoFuncDeclaration;
 import no.ssb.dlp.pseudo.core.func.PseudoFuncRule;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.util.LinkedHashMap;
 import java.util.List;
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -82,7 +82,8 @@ public class PseudoController {
             PseudoField pseudoField = new PseudoField(req.getName(), req.getPseudoFunc(), req.getKeyset());
 
             final String correlationId = validateOrCreate(clientCorrelationId);
-            MutableHttpResponse<Publisher<String>> mutableHttpResponse = HttpResponse.ok(pseudoField.process(pseudoConfigSplitter,
+            MutableHttpResponse<Publisher<String>> mutableHttpResponse = HttpResponse.ok(
+                    pseudoField.process(pseudoConfigSplitter,
                     recordProcessorFactory, req.values, PseudoOperation.PSEUDONYMIZE, correlationId));
             // TODO: Must hard-code to plain text to avoid that Micronaut converts the JSON to a JSON array
             mutableHttpResponse.contentType(MediaType.TEXT_PLAIN_TYPE).characterEncoding("UTF-8");
@@ -114,7 +115,7 @@ public class PseudoController {
             PseudoField pseudoField = new PseudoField(req.getName(), req.getPseudoFunc(), req.getKeyset());
 
             final String correlationId = validateOrCreate(clientCorrelationId);
-            MutableHttpResponse<Publisher<String>>  mutableHttpResponse = HttpResponse.ok(pseudoField.process(
+            MutableHttpResponse<Publisher<String>> mutableHttpResponse = HttpResponse.ok(pseudoField.process(
                     pseudoConfigSplitter, recordProcessorFactory,req.values, PseudoOperation.DEPSEUDONYMIZE, correlationId));
             // TODO: Must hard-code to plain text to avoid that Micronaut converts the JSON to a JSON array
             mutableHttpResponse.contentType(MediaType.TEXT_PLAIN_TYPE).characterEncoding("UTF-8");

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -38,8 +38,8 @@ import no.ssb.dlp.pseudo.service.sid.InvalidSidSnapshotDateException;
 import no.ssb.dlp.pseudo.service.sid.SidIndexUnavailableException;
 import org.reactivestreams.Publisher;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
@@ -1,10 +1,10 @@
 package no.ssb.dlp.pseudo.service.pseudo;
 
 import io.micronaut.context.annotation.Property;
+import jakarta.inject.Singleton;
 import no.ssb.dlp.pseudo.core.PseudoSecret;
 import no.ssb.dlp.pseudo.service.secrets.SecretService;
 
-import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
@@ -27,7 +27,6 @@ public class PseudoSecrets {
             Map<String, PseudoSecret> configuredPseudoSecrets) {
         this.secretService = secretService;
         this.configuredPseudoSecrets = Optional.ofNullable(configuredPseudoSecrets).orElse(Map.of());
-        System.out.println("TESTING");
     }
 
     /**

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
@@ -78,7 +78,7 @@ public class PseudoSecrets {
 
     }
 
-    class InvalidPseudoSecretException extends RuntimeException {
+    static class InvalidPseudoSecretException extends RuntimeException {
         public InvalidPseudoSecretException(String message) {
             super(message);
         }

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoSecrets.java
@@ -21,9 +21,13 @@ public class PseudoSecrets {
      *
      * @param configuredPseudoSecrets pseudo secrets coming from the config or environment
      */
-    public PseudoSecrets(SecretService secretService, @Property(name = "pseudo.secrets") Map<String, PseudoSecret> configuredPseudoSecrets) {
+    public PseudoSecrets(
+            SecretService secretService,
+            @Property(name = "pseudo.secrets")
+            Map<String, PseudoSecret> configuredPseudoSecrets) {
         this.secretService = secretService;
         this.configuredPseudoSecrets = Optional.ofNullable(configuredPseudoSecrets).orElse(Map.of());
+        System.out.println("TESTING");
     }
 
     /**

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoServiceTypeConverterRegistrar.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoServiceTypeConverterRegistrar.java
@@ -1,0 +1,27 @@
+package no.ssb.dlp.pseudo.service.pseudo;
+
+import io.micronaut.core.convert.MutableConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import jakarta.inject.Singleton;
+import no.ssb.dlp.pseudo.core.PseudoSecret;
+import no.ssb.dlp.pseudo.core.func.PseudoFuncRule;
+import no.ssb.dlp.pseudo.core.typeconverter.PseudoFuncRuleTypeConverter;
+import no.ssb.dlp.pseudo.core.typeconverter.PseudoSecretTypeConverter;
+
+import java.util.Map;
+
+/**
+ *  Micronaut {@link io.micronaut.core.convert.TypeConverter} implementations defined in a different
+ *  package like the ones from {@link no.ssb.dlp.pseudo.core} need to be manually registered
+ *  using this {@link io.micronaut.core.convert.TypeConverterRegistrar} implementation.
+ *
+ * @author Nicholas Jaunsen
+ */
+@Singleton
+public class PseudoServiceTypeConverterRegistrar implements TypeConverterRegistrar {
+    @Override
+    public void register(MutableConversionService conversionService) {
+        conversionService.addConverter(Map.class, PseudoSecret.class, new PseudoSecretTypeConverter());
+        conversionService.addConverter(Map.class, PseudoFuncRule.class, new PseudoFuncRuleTypeConverter());
+    }
+}

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoServiceTypeConverterRegistrar.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoServiceTypeConverterRegistrar.java
@@ -14,8 +14,6 @@ import java.util.Map;
  *  Micronaut {@link io.micronaut.core.convert.TypeConverter} implementations defined in a different
  *  package like the ones from {@link no.ssb.dlp.pseudo.core} need to be manually registered
  *  using this {@link io.micronaut.core.convert.TypeConverterRegistrar} implementation.
- *
- * @author Nicholas Jaunsen
  */
 @Singleton
 public class PseudoServiceTypeConverterRegistrar implements TypeConverterRegistrar {

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
@@ -1,5 +1,6 @@
 package no.ssb.dlp.pseudo.service.pseudo;
 
+import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import no.ssb.dapla.dlp.pseudo.func.PseudoFuncInput;
 import no.ssb.dapla.dlp.pseudo.func.PseudoFuncOutput;
@@ -23,7 +24,6 @@ import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetric;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.PseudoMetadataProcessor;
 
-import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.List;
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/StreamProcessorFactory.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/StreamProcessorFactory.java
@@ -8,7 +8,7 @@ import no.ssb.dlp.pseudo.core.json.JsonStreamProcessor;
 import no.ssb.dlp.pseudo.core.csv.CsvStreamProcessor;
 import no.ssb.dlp.pseudo.core.map.RecordMapProcessor;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @RequiredArgsConstructor
 @Singleton

--- a/src/main/java/no/ssb/dlp/pseudo/service/secrets/GcpSecretService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/secrets/GcpSecretService.java
@@ -6,11 +6,11 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.gcp.condition.RequiresGoogleProjectId;
 import io.micronaut.gcp.secretmanager.client.SecretManagerClient;
 import io.micronaut.gcp.secretmanager.client.VersionedSecret;
+import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
-import javax.inject.Singleton;
 import java.util.Optional;
 
 @RequiredArgsConstructor

--- a/src/main/java/no/ssb/dlp/pseudo/service/secrets/LocalSecretService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/secrets/LocalSecretService.java
@@ -1,9 +1,9 @@
 package no.ssb.dlp.pseudo.service.secrets;
 
 import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 
-import javax.inject.Singleton;
 import java.util.Optional;
 
 @RequiredArgsConstructor

--- a/src/main/java/no/ssb/dlp/pseudo/service/secrets/MockSecretService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/secrets/MockSecretService.java
@@ -3,7 +3,7 @@ package no.ssb.dlp.pseudo.service.secrets;
 import io.micronaut.context.annotation.Requires;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.nio.charset.StandardCharsets;
 
 @Singleton

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
@@ -47,13 +47,13 @@ public class CustomRolesFinder implements RolesFinder {
         }
         if (rolesConfig.getAdminsGroup().isPresent()) {
             final List<Membership> adminMembers = cloudIdentityService.listMembers(rolesConfig.getAdminsGroup().get());
-            if (adminMembers.stream().anyMatch(value -> value.getPreferredMemberKey().getId().equals(username))) {
+            if (adminMembers.stream().anyMatch(value -> value.preferredMemberKey().id().equals(username))) {
                 roles.add(PseudoServiceRole.ADMIN);
             }
         }
         if (rolesConfig.getUsersGroup().isPresent()) {
             final List<Membership> adminMembers = cloudIdentityService.listMembers(rolesConfig.getUsersGroup().get());
-            if (adminMembers.stream().anyMatch(value -> value.getPreferredMemberKey().getId().equals(username))) {
+            if (adminMembers.stream().anyMatch(value -> value.preferredMemberKey().id().equals(username))) {
                 roles.add(PseudoServiceRole.USER);
             }
         }

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinder.java
@@ -8,12 +8,12 @@ import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.security.token.DefaultRolesFinder;
 import io.micronaut.security.token.RolesFinder;
 import io.micronaut.security.token.config.TokenConfiguration;
+import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.ssb.dlp.pseudo.service.accessgroups.CloudIdentityService;
 import no.ssb.dlp.pseudo.service.accessgroups.Membership;
 
-import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
@@ -3,7 +3,6 @@ package no.ssb.dlp.pseudo.service.security;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import lombok.Data;
 
-import jakarta.validation.constraints.NotBlank;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +10,6 @@ import java.util.Optional;
 @ConfigurationProperties("app-roles")
 @Data
 public class StaticRolesConfig {
-    @NotBlank
     private List<String> users = new ArrayList<>();
     private List<String> admins = new ArrayList<>();
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
@@ -3,7 +3,7 @@ package no.ssb.dlp.pseudo.service.security;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
@@ -5,17 +5,21 @@ import io.micronaut.core.async.publisher.Publishers;
 import lombok.RequiredArgsConstructor;
 import org.reactivestreams.Publisher;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 @Singleton
-@RequiredArgsConstructor
+//@RequiredArgsConstructor
 @Requires(notEnv = "local-sid")
 public class ExternalSidService implements SidService {
 
     private final SidClient sidClient;
+
+    public ExternalSidService(SidClient sc) {
+        this.sidClient = sc;
+    }
 
     @Override
     public Publisher<SidInfo> lookupFnr(String fnr, Optional<String> snapshot) {

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/ExternalSidService.java
@@ -11,15 +11,11 @@ import java.util.Map;
 import java.util.Optional;
 
 @Singleton
-//@RequiredArgsConstructor
+@RequiredArgsConstructor
 @Requires(notEnv = "local-sid")
 public class ExternalSidService implements SidService {
 
     private final SidClient sidClient;
-
-    public ExternalSidService(SidClient sc) {
-        this.sidClient = sc;
-    }
 
     @Override
     public Publisher<SidInfo> lookupFnr(String fnr, Optional<String> snapshot) {

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/IdTokenFilter.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/IdTokenFilter.java
@@ -8,10 +8,10 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
+import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 
-import javax.inject.Singleton;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -49,7 +49,7 @@ class LocalSidService implements SidService {
                                     new SidInfo.SidInfoBuilder().snr(currentSnr).fnr(currentFnr)
                                             .datasetExtractionSnapshotTime(snapshot.orElse(null)).build())
                             .orElse(null);
-                }).collect(Collectors.toMap(SidInfo::getFnr, sidInfo -> sidInfo))
+                }).collect(Collectors.toMap(SidInfo::fnr, sidInfo -> sidInfo))
         );
     }
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import no.ssb.dlp.pseudo.service.sid.local.SidCache;
 import org.reactivestreams.Publisher;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidServiceController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidServiceController.java
@@ -30,10 +30,10 @@ public class LocalSidServiceController {
     @Post("/sid/map")
     public Publisher<SidInfo> lookup(@Body SidRequest sidRequest) {
         if (sidRequest.getFnr() != null) {
-            return sidService.lookupFnr(sidRequest.getFnr(), Optional.ofNullable(null));
+            return sidService.lookupFnr(sidRequest.getFnr(), Optional.empty());
         }
         if (sidRequest.getSnr() != null) {
-            return sidService.lookupSnr(sidRequest.getSnr(), Optional.ofNullable(null));
+            return sidService.lookupSnr(sidRequest.getSnr(), Optional.empty());
         }
         return null;
     }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidLookupResponse.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidLookupResponse.java
@@ -2,7 +2,6 @@ package no.ssb.dlp.pseudo.service.sid;
 
 import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
 import java.util.List;

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidLookupResponse.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidLookupResponse.java
@@ -1,16 +1,13 @@
 package no.ssb.dlp.pseudo.service.sid;
 
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
 import java.util.List;
 
-@Data
 @Builder
 @Jacksonized
-public class MultiSidLookupResponse {
-
-    private final List<String> missing;
-    private final String datasetExtractionSnapshotTime;
-}
+@Serdeable
+public record MultiSidLookupResponse (List<String> missing, String datasetExtractionSnapshotTime) {}

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidRequest.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidRequest.java
@@ -3,7 +3,6 @@ package no.ssb.dlp.pseudo.service.sid;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
 import java.util.List;

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidRequest.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidRequest.java
@@ -1,15 +1,15 @@
 package no.ssb.dlp.pseudo.service.sid;
 
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
 import java.util.List;
 
-@Data
 @Builder
 @Jacksonized
-public class MultiSidRequest {
-    private final List<String> fnrList;
-    private final String datasetExtractionSnapshotTime;
-}
+@Introspected
+@Serdeable.Deserializable
+public record MultiSidRequest(List<String> fnrList, String datasetExtractionSnapshotTime) { }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidResponse.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/MultiSidResponse.java
@@ -1,5 +1,6 @@
 package no.ssb.dlp.pseudo.service.sid;
 
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
@@ -12,6 +13,7 @@ import java.util.Map;
 @Data
 @Builder
 @Jacksonized
+@Serdeable
 public class MultiSidResponse {
 
     private final Mapping mapping;

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidClient.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidClient.java
@@ -12,15 +12,15 @@ import org.reactivestreams.Publisher;
 @IdTokenFilterMatcher()
 public interface SidClient {
 
-    @Post( "/sid/map")
+    @Post("/sid/map")
     @ExecuteOn(TaskExecutors.IO)
     Publisher<SidInfo> lookup(@Body SidRequest sidRequest);
 
-    @Post( "/sid/map/batch")
+    @Post("/sid/map/batch")
     @ExecuteOn(TaskExecutors.IO)
     Publisher<MultiSidResponse> lookup(@Body MultiSidRequest multiSidRequest);
 
-    @Get( "/sid/snapshots")
+    @Get("/sid/snapshots")
     @ExecuteOn(TaskExecutors.IO)
     Publisher<SnapshotInfo> snapshots();
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidInfo.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidInfo.java
@@ -1,14 +1,10 @@
 package no.ssb.dlp.pseudo.service.sid;
 
+import io.micronaut.serde.annotation.Serdeable;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
-@Data
 @Builder
 @Jacksonized
-public class SidInfo {
-    private final String fnr;
-    private final String snr;
-    private final String datasetExtractionSnapshotTime;
-}
+@Serdeable
+public record SidInfo (String fnr, String snr, String datasetExtractionSnapshotTime) {}

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidLookupController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidLookupController.java
@@ -39,13 +39,13 @@ public class SidLookupController {
     @Secured({PseudoServiceRole.USER, PseudoServiceRole.ADMIN})
     @Post("/lookup/batch")
     public Publisher<MultiSidLookupResponse> lookupMissing(@QueryValue Optional<String> snapshot, @Body MultiSidRequest req) {
-        return sidService.lookupMissing(req.getFnrList(), snapshot);
+        return sidService.lookupMissing(req.fnrList(), snapshot);
     }
 
     @ExecuteOn(TaskExecutors.IO)
     @Post("/map/batch")
     public Publisher<Map<String, SidInfo>> lookupFnrs(@QueryValue Optional<String> snapshot, @Body MultiSidRequest req) {
-        return sidService.lookupFnr(req.getFnrList(), snapshot);
+        return sidService.lookupFnr(req.fnrList(), snapshot);
     }
 
     @ExecuteOn(TaskExecutors.IO)

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
@@ -45,11 +45,11 @@ public class SidMapper implements Mapper {
     public SidMapper() {
         sidService = Application.getContext().getBean(SidService.class);
         partitionSize = Application.getContext().getProperty("sid.mapper.partition.size", Integer.class,
-                DEFAULT_PARTITION_SIZE).intValue();
+                DEFAULT_PARTITION_SIZE);
     }
 
-    private Set<String> fnrs = ConcurrentHashMap.newKeySet();
-    private ConcurrentHashMap<String, ObservableSubscriber<Map<String, SidInfo>>> bulkRequest = new ConcurrentHashMap<>();
+    private final Set<String> fnrs = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<String, ObservableSubscriber<Map<String, SidInfo>>> bulkRequest = new ConcurrentHashMap<>();
 
     @Override
     public void init(PseudoFuncInput input) {
@@ -186,8 +186,7 @@ public class SidMapper implements Mapper {
 
         @Override
         public void onError(Throwable throwable) {
-            if (throwable instanceof HttpClientResponseException) {
-                HttpClientResponseException exception = (HttpClientResponseException) throwable;
+            if (throwable instanceof HttpClientResponseException exception) {
                 if (exception.getStatus() == HttpStatus.NOT_FOUND) {
                     // This may happen more frequently, so log at debug level
                     log.debug("Error was", exception);

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/SidMapper.java
@@ -91,21 +91,21 @@ public class SidMapper implements Mapper {
                 log.warn("No SID-mapping found for fnr starting with {}", Strings.padEnd(fnr, 6, ' ').substring(0, 6));
                 output.addWarning(String.format("No SID-mapping found for fnr %s", fnr));
                 output.add(fnr);
-            } else if (result.getSnr() == null) {
+            } else if (result.snr() == null) {
                 log.warn("No SID-mapping found for fnr starting with {}", Strings.padEnd(fnr, 6, ' ').substring(0, 6));
-                output.addMetadata(MapFuncConfig.Param.SNAPSHOT_DATE, result.getDatasetExtractionSnapshotTime());
+                output.addMetadata(MapFuncConfig.Param.SNAPSHOT_DATE, result.datasetExtractionSnapshotTime());
                 output.addWarning(String.format("No SID-mapping found for fnr %s", fnr));
                 output.add(fnr);
             } else {
-                if (fnr.equals(result.getSnr())) {
+                if (fnr.equals(result.snr())) {
                     log.warn("Incorrect SID-mapping for fnr starting with {}. Mapping returned the original fnr!",
                             Strings.padEnd(fnr, 6, ' ').substring(0, 6));
                     output.addWarning(String.format("Incorrect SID-mapping for fnr %s. Mapping returned the original fnr!", fnr));
                 } else {
                     log.debug("Successfully mapped fnr starting with {}", Strings.padEnd(fnr, 6, ' ').substring(0, 6));
                 }
-                output.addMetadata(MapFuncConfig.Param.SNAPSHOT_DATE, result.getDatasetExtractionSnapshotTime());
-                output.add(result.getSnr());
+                output.addMetadata(MapFuncConfig.Param.SNAPSHOT_DATE, result.datasetExtractionSnapshotTime());
+                output.add(result.snr());
             }
         } catch (LocalSidService.NoSidMappingFoundException e) {
             log.warn("No SID-mapping found for fnr starting with {}", Strings.padEnd(fnr, 6, ' ').substring(0, 6));

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/local/SidCacheLoader.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/local/SidCacheLoader.java
@@ -69,9 +69,7 @@ public class SidCacheLoader {
                 },
 
                 // onComplete
-                () -> {
-                    sidCache.markAsInitialized();
-                }
+                sidCache::markAsInitialized
         );
 
         log.info("Read %s sid mappings in %s".formatted(

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/local/SidCacheLoader.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/local/SidCacheLoader.java
@@ -59,9 +59,8 @@ public class SidCacheLoader {
 
         sidReader.readSidsFromFile(item.getInputStream()).subscribe(
                 // onNext
-                sidItem -> {
-                    sidCache.register(sidItem, true);
-                },
+                sidItem -> sidCache.register(sidItem, true)
+                ,
 
                 // onError
                 e -> {

--- a/src/main/java/no/ssb/dlp/pseudo/service/tink/KmsConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/tink/KmsConfig.java
@@ -5,7 +5,7 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.core.annotation.Introspected;
 import lombok.Data;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/no/ssb/dlp/pseudo/service/tink/TinkInitizializer.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/tink/TinkInitizializer.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.ssb.crypto.tink.fpe.FpeConfig;
 import no.ssb.dlp.pseudo.core.PseudoException;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.net.URI;
 import java.util.Optional;
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,6 @@
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>

--- a/src/test/java/no/ssb/dlp/pseudo/service/ApplicationTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/ApplicationTest.java
@@ -2,10 +2,9 @@ package no.ssb.dlp.pseudo.service;
 
 import io.micronaut.runtime.EmbeddedApplication;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
 
 @MicronautTest
 class ApplicationTest {

--- a/src/test/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityServiceTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/accessgroups/CloudIdentityServiceTest.java
@@ -3,9 +3,8 @@ package no.ssb.dlp.pseudo.service.accessgroups;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
 
 import java.util.List;
 

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/ExternalSidServiceTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/ExternalSidServiceTest.java
@@ -5,7 +5,7 @@ import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidLookupControllerE2ETest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidLookupControllerE2ETest.java
@@ -6,13 +6,13 @@ import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.token.generator.TokenGenerator;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.restassured.specification.RequestSpecification;
+import jakarta.inject.Inject;
 import no.ssb.dlp.pseudo.service.security.PseudoServiceRole;
 import no.ssb.dlp.pseudo.service.sid.local.SidCache;
 import no.ssb.dlp.pseudo.service.sid.local.SidReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.Optional;
 import java.util.Set;
 

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidLookupControllerTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidLookupControllerTest.java
@@ -9,10 +9,10 @@ import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import jakarta.inject.Inject;
 import no.ssb.dlp.pseudo.service.security.PseudoServiceRole;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
@@ -12,7 +12,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Upgrade micronaut to major version 4 and apply recommended changes from their migration guide:
https://micronaut.io/2023/05/09/upgrade-to-micronaut-framework-4-0-0

PS: `dapla-dpl-psuedo-core` has also been upgraded to micronaut v4. Relevant PR found [here](https://github.com/statisticsnorway/dapla-dlp-pseudo-core/pull/37)