### PR TITLE
Identifiers such as FNR or SNR should be masked in both logs and metadata

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/Redactor.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/Redactor.java
@@ -8,7 +8,7 @@ import com.google.common.base.Strings;
 public class Redactor {
 
     static int MAX_VISIBLE_CHARS_FNR = 6;
-    static int MAX_VISIBLE_CHARS_SNR = 4;
+    static int MAX_VISIBLE_CHARS_SNR = 3;
 
     private Redactor() {
     }

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/Redactor.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/Redactor.java
@@ -1,0 +1,31 @@
+package no.ssb.dlp.pseudo.service.sid;
+
+import com.google.common.base.Strings;
+
+/**
+ * Redacts identifiers used by SID mapping.
+ */
+public class Redactor {
+
+    static int MAX_VISIBLE_CHARS_FNR = 6;
+    static int MAX_VISIBLE_CHARS_SNR = 4;
+
+    private Redactor() {
+    }
+
+    public static String redactFnr(String fnr) {
+        return redact(fnr, MAX_VISIBLE_CHARS_FNR);
+    }
+
+    public static String redactSnr(String snr) {
+        return redact(snr, MAX_VISIBLE_CHARS_SNR);
+    }
+
+    public static String redact(String identifier, int maxVisibleChars) {
+        if (identifier == null || identifier.length() <= maxVisibleChars) {
+            return identifier;
+        } else {
+            return identifier.substring(0, maxVisibleChars) + Strings.repeat("*", identifier.length() - maxVisibleChars);
+        }
+    }
+}

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/RedactorTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/RedactorTest.java
@@ -18,6 +18,6 @@ public class RedactorTest {
     }
     @Test
     public void redactSnr() {
-        Assertions.assertEquals("0001***", Redactor.redactSnr("0001ha3"));
+        Assertions.assertEquals("000****", Redactor.redactSnr("0001ha3"));
     }
 }

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/RedactorTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/RedactorTest.java
@@ -1,0 +1,23 @@
+package no.ssb.dlp.pseudo.service.sid;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RedactorTest {
+
+    @Test
+    public void redactVariableStrings() {
+        Assertions.assertNull(Redactor.redact(null, 4));
+        Assertions.assertEquals("123", Redactor.redact("123", 4));
+        Assertions.assertEquals("1234", Redactor.redact("1234", 4));
+        Assertions.assertEquals("1234****", Redactor.redact("12345678", 4));
+    }
+    @Test
+    public void redactFnr() {
+        Assertions.assertEquals("118548*****", Redactor.redactFnr("11854898347"));
+    }
+    @Test
+    public void redactSnr() {
+        Assertions.assertEquals("0001***", Redactor.redactSnr("0001ha3"));
+    }
+}

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
@@ -222,7 +222,7 @@ public class SidMapperTest {
             mapper.init(PseudoFuncInput.of("0001ha3"));
             PseudoFuncOutput output = mapper.restore(PseudoFuncInput.of("0001ha3"));
 
-            Assertions.assertEquals("Incorrect SID-mapping for snr 0001***. Mapping returned the original snr!", output.getWarnings().getFirst());
+            Assertions.assertEquals("Incorrect SID-mapping for snr 000****. Mapping returned the original snr!", output.getWarnings().getFirst());
             verify(sidService, times(1)).lookupSnr(anyList(), eq(Optional.empty()));
             assertLogsForFnrOrSnr("11854898346", "0001ha3");
         }
@@ -241,7 +241,7 @@ public class SidMapperTest {
             mapper.init(PseudoFuncInput.of("0001ha3"));
             PseudoFuncOutput output = mapper.restore(PseudoFuncInput.of("0001ha3"));
 
-            Assertions.assertEquals("No SID-mapping found for snr 0001***", output.getWarnings().getFirst());
+            Assertions.assertEquals("No SID-mapping found for snr 000****", output.getWarnings().getFirst());
             verify(sidService, times(1)).lookupSnr(anyList(), eq(Optional.empty()));
             assertLogsForFnrOrSnr("11854898346", "0001ha3");
         }

--- a/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/sid/SidMapperTest.java
@@ -165,7 +165,7 @@ public class SidMapperTest {
             PseudoFuncOutput output = mapper.map(PseudoFuncInput.of("11854898346"));
 
 
-            Assertions.assertEquals("Incorrect SID-mapping for fnr 118548. Mapping returned the original fnr!", output.getWarnings().getFirst());
+            Assertions.assertEquals("Incorrect SID-mapping for fnr 118548*****. Mapping returned the original fnr!", output.getWarnings().getFirst());
             verify(sidService, times(1)).lookupFnr(anyList(), eq(Optional.empty()));
             assertLogsForFnrOrSnr("11854898346", "");
         }
@@ -184,7 +184,7 @@ public class SidMapperTest {
             mapper.init(PseudoFuncInput.of("11854898346"));
             PseudoFuncOutput output = mapper.map(PseudoFuncInput.of("11854898346"));
 
-            Assertions.assertEquals("No SID-mapping found for fnr 118548", output.getWarnings().getFirst());
+            Assertions.assertEquals("No SID-mapping found for fnr 118548*****", output.getWarnings().getFirst());
             verify(sidService, times(1)).lookupFnr(anyList(), eq(Optional.empty()));
             assertLogsForFnrOrSnr("11854898346", "");
         }
@@ -222,7 +222,7 @@ public class SidMapperTest {
             mapper.init(PseudoFuncInput.of("0001ha3"));
             PseudoFuncOutput output = mapper.restore(PseudoFuncInput.of("0001ha3"));
 
-            Assertions.assertEquals("Incorrect SID-mapping for snr 0001. Mapping returned the original snr!", output.getWarnings().getFirst());
+            Assertions.assertEquals("Incorrect SID-mapping for snr 0001***. Mapping returned the original snr!", output.getWarnings().getFirst());
             verify(sidService, times(1)).lookupSnr(anyList(), eq(Optional.empty()));
             assertLogsForFnrOrSnr("11854898346", "0001ha3");
         }
@@ -241,7 +241,7 @@ public class SidMapperTest {
             mapper.init(PseudoFuncInput.of("0001ha3"));
             PseudoFuncOutput output = mapper.restore(PseudoFuncInput.of("0001ha3"));
 
-            Assertions.assertEquals("No SID-mapping found for snr 0001", output.getWarnings().getFirst());
+            Assertions.assertEquals("No SID-mapping found for snr 0001***", output.getWarnings().getFirst());
             verify(sidService, times(1)).lookupSnr(anyList(), eq(Optional.empty()));
             assertLogsForFnrOrSnr("11854898346", "0001ha3");
         }


### PR DESCRIPTION
- Created a Redactor class for redacting identifiers
- Also fixed missing metadata in depseudonymize.