### PR TITLE
Fix OpenAPI docs

### DIFF
--- a/openapi.properties
+++ b/openapi.properties
@@ -1,11 +1,7 @@
-mapping.path=api-docs
-
-swagger-ui.enabled=true
-
-redoc.enabled=true
-rapidoc.enabled=true
-#rapidoc.bg-color=#14191f
-#rapidoc.text-color=#aec2e0
-#rapidoc.sort-endpoints-by=method
-
-redoc.description=blah
+micronaut.openapi.views.spec = mapping.path=/,\
+  swagger-ui.enabled=true,\
+  redoc.enabled=true,\
+  redoc.description=blah,\
+  openapi-explorer.enabled=true,\
+  rapidoc.enabled=true
+micronaut.openapi.server.context.path=/api-docs


### PR DESCRIPTION
Fixes bug where API documentation wasn't rendered because of some changed openapi properties in the new version of `micronaut-openapi`.

![Screenshot 2024-03-11 at 10 12 24](https://github.com/statisticsnorway/dapla-dlp-pseudo-service/assets/3789764/d9f826cd-5391-4b3d-861d-ef0780296028)
