### PR TITLE
Add missing encryptionKeyReference to metadata. Simplify code.

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/RecordMapProcessorFactory.java
@@ -33,7 +33,6 @@ import java.util.List;
 import static no.ssb.dlp.pseudo.core.PseudoOperation.DEPSEUDONYMIZE;
 import static no.ssb.dlp.pseudo.core.PseudoOperation.PSEUDONYMIZE;
 import static no.ssb.dlp.pseudo.core.func.PseudoFuncDeclaration.*;
-import static no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata.*;
 
 @RequiredArgsConstructor
 @Singleton
@@ -131,17 +130,6 @@ public class RecordMapProcessorFactory {
                 if (isSidMapping && varValue.equals(mappedValue)) {
                     // Unsuccessful SID-mapping
                     metadataProcessor.addMetric(FieldMetric.MISSING_SID);
-                } else if (isSidMapping) {
-                    metadataProcessor.addMetric(FieldMetric.MAPPED_SID);
-                    metadataProcessor.addMetadata(FieldMetadata.builder()
-                            .shortName(field.getName())
-                            .dataElementPath(field.getPath().substring(1).replace('/', '.')) // Skip leading slash and use dot as separator
-                            .dataElementPattern(match.getRule().getPattern())
-                            .encryptionAlgorithm(match.getFunc().getAlgorithm())
-                            .stableIdentifierVersion(sidSnapshotDate)
-                            .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
-                            .encryptionAlgorithmParameters(funcDeclaration.getArgs())
-                            .build());
                 } else {
                     metadataProcessor.addMetadata(FieldMetadata.builder()
                             .shortName(field.getName())
@@ -149,8 +137,13 @@ public class RecordMapProcessorFactory {
                             .dataElementPattern(match.getRule().getPattern())
                             .encryptionKeyReference(funcDeclaration.getArgs().getOrDefault(KEY_REFERENCE, null))
                             .encryptionAlgorithm(match.getFunc().getAlgorithm())
+                            .stableIdentifierVersion(sidSnapshotDate)
+                            .stableIdentifierType(isSidMapping)
                             .encryptionAlgorithmParameters(funcDeclaration.getArgs())
                             .build());
+                }
+                if (isSidMapping) {
+                    metadataProcessor.addMetric(FieldMetric.MAPPED_SID);
                 }
                 return mappedValue;
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/metadata/FieldMetadata.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/metadata/FieldMetadata.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class FieldMetadata {
 
     // Type of stable ID identifier that is used prior to pseudonymization. Currently only FREG_SNR is supported.
-    public static final String STABLE_IDENTIFIER_TYPE = "FREG_SNR";
+    private static final String STABLE_IDENTIFIER_TYPE = "FREG_SNR";
 
     String shortName;
     String dataElementPath;
@@ -21,7 +21,7 @@ public class FieldMetadata {
     String encryptionKeyReference;
     String encryptionAlgorithm;
     String stableIdentifierVersion;
-    String stableIdentifierType;
+    boolean stableIdentifierType;
     Map<String, String> encryptionAlgorithmParameters;
 
     public PseudoVariable toDatadocPseudoVariable() {
@@ -34,7 +34,7 @@ public class FieldMetadata {
                 .withEncryptionAlgorithmParameters(
                         toEncryptionAlgorithmParameters())
                 .withStableIdentifierVersion(stableIdentifierVersion)
-                .withStableIdentifierType(stableIdentifierType)
+                .withStableIdentifierType(stableIdentifierType ? STABLE_IDENTIFIER_TYPE : null)
                 .build();
     }
 

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata.*;
 import static org.mockito.Mockito.*;
 
 @MicronautTest
@@ -50,7 +49,7 @@ class DepseudoFieldTest {
                 .encryptionAlgorithm("algorithm")
                 .encryptionAlgorithmParameters(Map.of("key", "value"))
                 .stableIdentifierVersion("stableIdVersion")
-                .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
+                .stableIdentifierType(true)
             .build());
         processor.addLog("Log line");
         return processor;

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -4,12 +4,10 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.observers.TestObserver;
-import io.reactivex.processors.ReplayProcessor;
 import no.ssb.dlp.pseudo.core.PseudoOperation;
 import no.ssb.dlp.pseudo.core.map.RecordMapProcessor;
 import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata;
-import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetric;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.PseudoMetadataProcessor;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -23,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -81,7 +78,7 @@ class PseudoFieldTest {
                 .encryptionAlgorithm("algorithm")
                 .encryptionAlgorithmParameters(Map.of("key", "value"))
                 .stableIdentifierVersion("stableIdVersion")
-                .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
+                .stableIdentifierType(true)
                 .build());
         processor.addLog("Log line");
         return processor;

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
@@ -2,10 +2,8 @@ package no.ssb.dlp.pseudo.service.pseudo;
 
 import com.google.common.collect.Lists;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import io.reactivex.processors.ReplayProcessor;
 import no.ssb.dlp.pseudo.core.map.RecordMapProcessor;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata;
-import no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetric;
 import no.ssb.dlp.pseudo.service.pseudo.metadata.PseudoMetadataProcessor;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -19,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static no.ssb.dlp.pseudo.service.pseudo.metadata.FieldMetadata.*;
 import static org.mockito.Mockito.*;
 
 @MicronautTest
@@ -50,7 +47,7 @@ class RepseudoFieldTest {
                 .encryptionAlgorithm("algorithm")
                 .encryptionAlgorithmParameters(Map.of("key", "value"))
                 .stableIdentifierVersion("stableIdVersion")
-                .stableIdentifierType(STABLE_IDENTIFIER_TYPE)
+                .stableIdentifierType(true)
                 .build());
         processor.addLog("Log line");
         return processor;


### PR DESCRIPTION
This PR will remove some duplicate code, and also corrrects a missing encryptionKeyReference in metadata.