### PR TITLE
Add extra security measure for isAuthenticated()

### DIFF
--- a/conf/application-local.yml
+++ b/conf/application-local.yml
@@ -40,6 +40,8 @@ micronaut:
           jwks:
             keycloak-staging:
               url: 'https://keycloak.staging-bip-app.ssb.no/auth/realms/ssb/protocol/openid-connect/certs'
+            google:
+              url: 'https://www.googleapis.com/oauth2/v3/certs'
 
   http:
     services:
@@ -117,6 +119,9 @@ pseudo.secrets:
     type: TINK_WDEK
 
 app-roles:
+  # When using isAuthenticated() the JWT token must be signed by one of the trusted-issuers
+  trusted-issuers:
+    - https://keycloak.staging-bip-app.ssb.no/auth/realms/ssb
   users:
     - isAuthenticated()
   admins:

--- a/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/security/StaticRolesConfig.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 @ConfigurationProperties("app-roles")
 @Data
 public class StaticRolesConfig {
+    private List<String> trustedIssuers = new ArrayList<>();
     private List<String> users = new ArrayList<>();
     private List<String> admins = new ArrayList<>();
 

--- a/src/test/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinderTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/security/CustomRolesFinderTest.java
@@ -1,0 +1,89 @@
+package no.ssb.dlp.pseudo.service.security;
+
+import com.nimbusds.jwt.JWTClaimNames;
+import io.micronaut.security.rules.SecurityRule;
+import io.micronaut.security.token.config.TokenConfiguration;
+import io.micronaut.security.token.config.TokenConfigurationProperties;
+import no.ssb.dlp.pseudo.service.accessgroups.CloudIdentityService;
+import no.ssb.dlp.pseudo.service.accessgroups.EntityKey;
+import no.ssb.dlp.pseudo.service.accessgroups.Membership;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CustomRolesFinderTest {
+
+    CloudIdentityService cloudIdentityService = mock(CloudIdentityService.class);
+    StaticRolesConfig rolesConfig = mock(StaticRolesConfig.class);
+    TokenConfiguration tokenConfig = new TokenConfigurationProperties();
+    CustomRolesFinder sut = new CustomRolesFinder(tokenConfig, rolesConfig, cloudIdentityService);
+
+    @Test
+    void single_user_gets_no_roles() {
+        final String email = "john.doe@ssb.no";
+        assertIterableEquals(List.of(), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+    @Test
+    void single_user_get_user_role() {
+        final String email = "john.doe@ssb.no";
+        when(rolesConfig.getUsers()).thenReturn(List.of(email));
+        assertIterableEquals(List.of(PseudoServiceRole.USER), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+
+    @Test
+    void single_user_get_admin_role() {
+        final String email = "john.doe@ssb.no";
+        when(rolesConfig.getAdmins()).thenReturn(List.of(email));
+        assertIterableEquals(List.of(PseudoServiceRole.ADMIN), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+
+    @Test
+    void single_user_get_multiple_roles() {
+        final String email = "john.doe@ssb.no";
+        when(rolesConfig.getUsers()).thenReturn(List.of(email));
+        when(rolesConfig.getAdmins()).thenReturn(List.of(email));
+        assertIterableEquals(List.of(PseudoServiceRole.ADMIN, PseudoServiceRole.USER), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+
+    @Test
+    void group_membership_user_role() {
+        final String email = "john.doe@ssb.no";
+        final String user_group = "user-group@ssb.no";
+        when(rolesConfig.getUsersGroup()).thenReturn(Optional.of(user_group));
+        when(cloudIdentityService.listMembers(eq(user_group)))
+                .thenReturn(List.of(new Membership("John Doe", new EntityKey(email, "ssb"))));
+        assertIterableEquals(List.of(PseudoServiceRole.USER), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+
+    @Test
+    void group_membership_admin_role() {
+        final String email = "john.doe@ssb.no";
+        final String user_group = "user-group@ssb.no";
+        when(rolesConfig.getAdminsGroup()).thenReturn(Optional.of(user_group));
+        when(cloudIdentityService.listMembers(eq(user_group)))
+                .thenReturn(List.of(new Membership("John Doe", new EntityKey(email, "ssb"))));
+        assertIterableEquals(List.of(PseudoServiceRole.ADMIN), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+
+    @Test
+    void authenticated_user_gets_no_roles_when_issuer_not_trusted() {
+        final String email = "john.doe@ssb.no";
+        when(rolesConfig.getUsers()).thenReturn(List.of(SecurityRule.IS_AUTHENTICATED));
+        assertIterableEquals(List.of(), sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email)));
+    }
+
+    @Test
+    void authenticated_user_get_user_role_when_issuer_is_trusted() {
+        final String email = "john.doe@ssb.no";
+        final String trusted_issuer = "some-issuer-url/auth/realm";
+        when(rolesConfig.getUsers()).thenReturn(List.of(SecurityRule.IS_AUTHENTICATED));
+        when(rolesConfig.getTrustedIssuers()).thenReturn(List.of(trusted_issuer));
+        assertIterableEquals(List.of(PseudoServiceRole.USER),
+                sut.resolveRoles(Map.of(tokenConfig.getNameKey(), email, JWTClaimNames.ISSUER, trusted_issuer)));
+    }
+}


### PR DESCRIPTION
When using `isAuthenticated()` the JWT token must be signed by a trusted issuer. The property `micronaut.security.token.jwt.signatures.jwks` is used to validate JWT tokens, but this is not enough to validate trusted issuers. For example, Google IdTokens can be issued by many different services.

This PR will restrict the use of `isAuthenticated()` to only trusted issuers like Keycloak.

Internal ticket ID: DPSTAT-888