### PR TITLE
Fix handling of new MapFailureStrategy parameter in SidMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dapla-datadoc-model.version>1.2</dapla-datadoc-model.version>
 
     <artifactregistry-maven-wagon.version>2.2.1</artifactregistry-maven-wagon.version>
-    <dapla-dlp-pseudo-core.version>2.0.6-SNAPSHOT</dapla-dlp-pseudo-core.version>
+    <dapla-dlp-pseudo-core.version>2.0.6</dapla-dlp-pseudo-core.version>
     <micronaut.version>4.3.7</micronaut.version>
     <micronaut.openapi.version>5.0.1</micronaut.openapi.version>
     <micronaut.object.storage.version>2.3.0</micronaut.object.storage.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dapla-datadoc-model.version>1.2</dapla-datadoc-model.version>
 
     <artifactregistry-maven-wagon.version>2.2.1</artifactregistry-maven-wagon.version>
-    <dapla-dlp-pseudo-core.version>2.0.5</dapla-dlp-pseudo-core.version>
+    <dapla-dlp-pseudo-core.version>2.0.6-SNAPSHOT</dapla-dlp-pseudo-core.version>
     <micronaut.version>4.3.7</micronaut.version>
     <micronaut.openapi.version>5.0.1</micronaut.openapi.version>
     <micronaut.object.storage.version>2.3.0</micronaut.object.storage.version>

--- a/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/sid/LocalSidService.java
@@ -1,10 +1,8 @@
 package no.ssb.dlp.pseudo.service.sid;
 
-import com.google.common.base.Strings;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.publisher.Publishers;
 import lombok.RequiredArgsConstructor;
-import no.ssb.dapla.dlp.pseudo.func.map.MappingNotFoundException;
 import no.ssb.dlp.pseudo.service.sid.local.SidCache;
 import org.reactivestreams.Publisher;
 
@@ -27,8 +25,7 @@ class LocalSidService implements SidService {
     @Override
     public Publisher<SidInfo> lookupFnr(String fnr, Optional<String> snapshot) {
         String currentSnr = sidCache.getCurrentSnrForFnr(fnr)
-                .orElseThrow(() -> new MappingNotFoundException("No SID matching fnr starting from="
-                        + Strings.padEnd(fnr, 6, ' ').substring(0, 6)));
+                .orElse(null);
         return Publishers.just(sidCache.getCurrentFnrForSnr(currentSnr).map(currentFnr ->
                         new SidInfo.SidInfoBuilder().snr(currentSnr).fnr(currentFnr).build())
                 .orElse(null));
@@ -37,8 +34,7 @@ class LocalSidService implements SidService {
     @Override
     public Publisher<SidInfo> lookupSnr(String snr, Optional<String> snapshot) {
         String currentFnr = sidCache.getCurrentFnrForSnr(snr)
-                .orElseThrow(() -> new MappingNotFoundException("No SID matching snr starting from="
-                        + Strings.padEnd(snr, 4, ' ').substring(0, 4)));
+                .orElse(null);
         return Publishers.just(sidCache.getCurrentSnrForFnr(currentFnr).map(currentSnr ->
                         new SidInfo.SidInfoBuilder().snr(currentSnr).fnr(currentFnr).build())
                 .orElse(null));


### PR DESCRIPTION
Instead of throwing `MappingNotFoundException ` the `SidMapper` should now respect the `MapFailureStrategy` parameter for handling mapping failures.