### PR TITLE
The pattern should be included in the payload to the pseudonymizeField endpoint.

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -79,7 +79,7 @@ public class PseudoController {
         try {
             PseudoFieldRequest req = Json.toObject(PseudoFieldRequest.class, request);
             log.info(Strings.padEnd(String.format("*** Pseudonymize field: %s ", req.getName()), 80, '*'));
-            PseudoField pseudoField = new PseudoField(req.getName(), req.getPseudoFunc(), req.getKeyset());
+            PseudoField pseudoField = new PseudoField(req.getName(), req.getPattern(), req.getPseudoFunc(), req.getKeyset());
 
             final String correlationId = MDC.get("CorrelationID");
 
@@ -109,7 +109,7 @@ public class PseudoController {
         try {
             DepseudoFieldRequest req = Json.toObject(DepseudoFieldRequest.class, request);
             log.info(Strings.padEnd(String.format("*** Depseudonymize field: %s ", req.getName()), 80, '*'));
-            PseudoField pseudoField = new PseudoField(req.getName(), req.getPseudoFunc(), req.getKeyset());
+            PseudoField pseudoField = new PseudoField(req.getName(), req.getPattern(), req.getPseudoFunc(), req.getKeyset());
 
             final String correlationId = MDC.get("CorrelationID");
 
@@ -139,8 +139,8 @@ public class PseudoController {
         try {
             RepseudoFieldRequest req = Json.toObject(RepseudoFieldRequest.class, request);
             log.info(Strings.padEnd(String.format("*** Repseudonymize field: %s ", req.getName()), 80, '*'));
-            PseudoField sourcePseudoField = new PseudoField(req.getName(), req.getSourcePseudoFunc(), req.getSourceKeyset());
-            PseudoField targetPseudoField = new PseudoField(req.getName(), req.getTargetPseudoFunc(), req.getTargetKeyset());
+            PseudoField sourcePseudoField = new PseudoField(req.getName(), req.getPattern(), req.getSourcePseudoFunc(), req.getSourceKeyset());
+            PseudoField targetPseudoField = new PseudoField(req.getName(), req.getPattern(), req.getTargetPseudoFunc(), req.getTargetKeyset());
 
             final String correlationId = MDC.get("CorrelationID");
             return HttpResponse.ok(
@@ -436,6 +436,7 @@ public class PseudoController {
         private String pseudoFunc;
         private EncryptedKeysetWrapper keyset;
         private String name;
+        private String pattern;
         private List<String> values;
     }
 
@@ -448,6 +449,7 @@ public class PseudoController {
         private String pseudoFunc;
         private EncryptedKeysetWrapper keyset;
         private String name;
+        private String pattern;
         private List<String> values;
     }
 
@@ -462,6 +464,7 @@ public class PseudoController {
         private EncryptedKeysetWrapper sourceKeyset;
         private EncryptedKeysetWrapper targetKeyset;
         private String name;
+        private String pattern;
         private List<String> values;
     }
 

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
@@ -39,21 +39,26 @@ public class PseudoField {
      * a default pseudo configuration is used.
      *
      * @param name       The name of the field.
+     * @param pattern    The pattern that matched the field.
      * @param pseudoFunc The pseudo function definition.
      * @param keyset     The encrypted keyset to be used for pseudonymization.
      */
-    public PseudoField(String name, String pseudoFunc, EncryptedKeysetWrapper keyset) {
+    public PseudoField(String name, String pattern, String pseudoFunc, EncryptedKeysetWrapper keyset) {
         this.name = name;
 
         pseudoConfig = new PseudoConfig();
 
+        // For backwards compatibility
+        if (pattern == null) {
+            pattern = "**";
+        }
         if (pseudoFunc == null) {
             pseudoFunc = DEFAULT_PSEUDO_FUNC;
         }
         if (keyset != null) {
             pseudoConfig.getKeysets().add(keyset);
         }
-        pseudoConfig.getRules().add(new PseudoFuncRule(name, "**", pseudoFunc));
+        pseudoConfig.getRules().add(new PseudoFuncRule(name, pattern, pseudoFunc));
     }
 
     /**

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/DepseudoFieldTest.java
@@ -68,7 +68,7 @@ class DepseudoFieldTest {
             return Collections.singletonMap("testField", "processedValue " + originalValue);
         });
 
-        PseudoField pseudoField = new PseudoField("testField", null, null);
+        PseudoField pseudoField = new PseudoField("testField", "**", null, null);
         List<String> values = Arrays.asList("v1", null, "v2");
 
         String want = """

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -38,7 +38,7 @@ class PseudoFieldTest {
 
     @Test
     void UsesDefaultPseudoConfigWhenNoKeysetIsSupplied() {
-        PseudoField pseudoField = new PseudoField(null, null, null);
+        PseudoField pseudoField = new PseudoField(null, "**", null, null);
         assertEquals(PseudoField.getDEFAULT_PSEUDO_FUNC(), pseudoField.getPseudoConfig().getRules().get(0).getFunc());
     }
 
@@ -46,7 +46,7 @@ class PseudoFieldTest {
     void usesCustomPseudoFuncWhenPseudoFuncIsSupplied() {
         int keySetPrimaryKey = 12345;
 
-        PseudoField pseudoSIDField = new PseudoField(null,  String.format("map-sid(keyId=%s)", keySetPrimaryKey), null);
+        PseudoField pseudoSIDField = new PseudoField(null, "**", String.format("map-sid(keyId=%s)", keySetPrimaryKey), null);
 
         assertEquals(String.format("map-sid(keyId=%s)", keySetPrimaryKey),
                 pseudoSIDField.getPseudoConfig().getRules().get(0).getFunc());
@@ -55,7 +55,7 @@ class PseudoFieldTest {
     @Test
     void setCustomKeysetWhenKeysetIsSupplied() {
         EncryptedKeysetWrapper encryptedKeysetWrapper = mock(EncryptedKeysetWrapper.class);
-        PseudoField pseudoField = new PseudoField(null, null, encryptedKeysetWrapper);
+        PseudoField pseudoField = new PseudoField(null, "**", null, encryptedKeysetWrapper);
 
         assertEquals(encryptedKeysetWrapper,
                 pseudoField.getPseudoConfig().getKeysets().get(0));
@@ -97,7 +97,7 @@ class PseudoFieldTest {
             return Collections.singletonMap("testField", "processedValue " + originalValue);
         });
 
-        PseudoField pseudoField = new PseudoField("testField", null, null);
+        PseudoField pseudoField = new PseudoField("testField", "**", null, null);
         List<String> values = Arrays.asList("v1", null, "v2");
 
         String want = """
@@ -153,7 +153,7 @@ class PseudoFieldTest {
         when(recordMapProcessor.hasPreprocessors()).thenReturn(true);
         when(recordMapProcessor.init(any())).thenReturn(Collections.singletonMap("testField", "initializedValue"));
 
-        PseudoField pseudoField = new PseudoField("testField", null, null);
+        PseudoField pseudoField = new PseudoField("testField", "**", null, null);
         List<String> values = Arrays.asList("v1", null, "v2");
 
         Completable result = pseudoField.getPreprocessor(values, recordMapProcessor);

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/RepseudoFieldTest.java
@@ -65,8 +65,8 @@ class RepseudoFieldTest {
             return Collections.singletonMap("testField", "processedValue " + originalValue);
         });
 
-        PseudoField sourcePseudoField = new PseudoField("testField", null, null);
-        PseudoField targetPseudoField = new PseudoField("testField", null, null);
+        PseudoField sourcePseudoField = new PseudoField("testField", "**", null, null);
+        PseudoField targetPseudoField = new PseudoField("testField", "**", null, null);
         List<String> values = Arrays.asList("v1", null, "v2");
 
         String want = """


### PR DESCRIPTION
In the generated datadoc the pattern was hard-coded to `**`. This can now be set as part of the request.