### PR TITLE
Validate the pattern that is sendt to the pseudonymizeField endpoint.

### DIFF
--- a/doc/requests/examples-field.http
+++ b/doc/requests/examples-field.http
@@ -45,6 +45,7 @@ Authorization: Bearer {{keycloak_token}}
 {
   "request": {
     "name": "fnr",
+    "pattern": "/fnr",
     "values": [
       "11854898347",
       "01839899544",

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoController.java
@@ -76,10 +76,10 @@ public class PseudoController {
     public HttpResponse<Flowable<byte[]>> pseudonymizeField(
             @Schema(implementation = PseudoFieldRequest.class) String request
     ) {
+        PseudoFieldRequest req = Json.toObject(PseudoFieldRequest.class, request);
+        log.info(Strings.padEnd(String.format("*** Pseudonymize field: %s ", req.getName()), 80, '*'));
+        PseudoField pseudoField = new PseudoField(req.getName(), req.getPattern(), req.getPseudoFunc(), req.getKeyset());
         try {
-            PseudoFieldRequest req = Json.toObject(PseudoFieldRequest.class, request);
-            log.info(Strings.padEnd(String.format("*** Pseudonymize field: %s ", req.getName()), 80, '*'));
-            PseudoField pseudoField = new PseudoField(req.getName(), req.getPattern(), req.getPseudoFunc(), req.getKeyset());
 
             final String correlationId = MDC.get("CorrelationID");
 
@@ -106,10 +106,10 @@ public class PseudoController {
     public HttpResponse<Flowable<byte[]>> depseudonymizeField(
             @Schema(implementation = DepseudoFieldRequest.class) String request
     ) {
+        DepseudoFieldRequest req = Json.toObject(DepseudoFieldRequest.class, request);
+        log.info(Strings.padEnd(String.format("*** Depseudonymize field: %s ", req.getName()), 80, '*'));
+        PseudoField pseudoField = new PseudoField(req.getName(), req.getPattern(), req.getPseudoFunc(), req.getKeyset());
         try {
-            DepseudoFieldRequest req = Json.toObject(DepseudoFieldRequest.class, request);
-            log.info(Strings.padEnd(String.format("*** Depseudonymize field: %s ", req.getName()), 80, '*'));
-            PseudoField pseudoField = new PseudoField(req.getName(), req.getPattern(), req.getPseudoFunc(), req.getKeyset());
 
             final String correlationId = MDC.get("CorrelationID");
 
@@ -136,11 +136,11 @@ public class PseudoController {
     public HttpResponse<Flowable<byte[]>> repseudonymizeField(
             @Schema(implementation = RepseudoFieldRequest.class) String request
     ) {
+        RepseudoFieldRequest req = Json.toObject(RepseudoFieldRequest.class, request);
+        log.info(Strings.padEnd(String.format("*** Repseudonymize field: %s ", req.getName()), 80, '*'));
+        PseudoField sourcePseudoField = new PseudoField(req.getName(), req.getPattern(), req.getSourcePseudoFunc(), req.getSourceKeyset());
+        PseudoField targetPseudoField = new PseudoField(req.getName(), req.getPattern(), req.getTargetPseudoFunc(), req.getTargetKeyset());
         try {
-            RepseudoFieldRequest req = Json.toObject(RepseudoFieldRequest.class, request);
-            log.info(Strings.padEnd(String.format("*** Repseudonymize field: %s ", req.getName()), 80, '*'));
-            PseudoField sourcePseudoField = new PseudoField(req.getName(), req.getPattern(), req.getSourcePseudoFunc(), req.getSourceKeyset());
-            PseudoField targetPseudoField = new PseudoField(req.getName(), req.getPattern(), req.getTargetPseudoFunc(), req.getTargetKeyset());
 
             final String correlationId = MDC.get("CorrelationID");
             return HttpResponse.ok(

--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import no.ssb.dlp.pseudo.core.PseudoOperation;
+import no.ssb.dlp.pseudo.core.field.FieldDescriptor;
 import no.ssb.dlp.pseudo.core.func.PseudoFuncRule;
 import no.ssb.dlp.pseudo.core.map.RecordMapProcessor;
 import no.ssb.dlp.pseudo.core.tink.model.EncryptedKeysetWrapper;
@@ -57,6 +58,11 @@ public class PseudoField {
         }
         if (keyset != null) {
             pseudoConfig.getKeysets().add(keyset);
+        }
+        final boolean validPattern = new FieldDescriptor(name).globMatches(pattern);
+        if (!validPattern) {
+            throw new IllegalArgumentException(String.format("The pattern '%s' will not match the field name '%s'. " +
+                    "Are you sure you didn't mean to use '/%s'?", pattern, name, pattern));
         }
         pseudoConfig.getRules().add(new PseudoFuncRule(name, pattern, pseudoFunc));
     }


### PR DESCRIPTION
This is a "sanity check" that ensures that the pattern actually will give a match to the provided pseudo function.

Previously the pattern was hard-coded to `**`. Now it should show the actual pattern that was used to match the field.