### PR TITLE
Regex replace name indices when validating glob

### DIFF
--- a/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
+++ b/src/main/java/no/ssb/dlp/pseudo/service/pseudo/PseudoField.java
@@ -59,10 +59,15 @@ public class PseudoField {
         if (keyset != null) {
             pseudoConfig.getKeysets().add(keyset);
         }
-        final boolean validPattern = new FieldDescriptor(name).globMatches(pattern);
-        if (!validPattern) {
-            throw new IllegalArgumentException(String.format("The pattern '%s' will not match the field name '%s'. " +
-                    "Are you sure you didn't mean to use '/%s'?", pattern, name, pattern));
+
+        if (name != null) {
+            // Regex replace such that "path[9]/thing" -> "path/thing"
+            String nameNoIndices = name.replaceAll("\\[.*?]", "");
+            final boolean validPattern = new FieldDescriptor(nameNoIndices).globMatches(pattern);
+            if (!validPattern) {
+                throw new IllegalArgumentException(String.format("The pattern '%s' will not match the field name '%s'. " +
+                        "Are you sure you didn't mean to use '/%s'?", pattern, name, pattern));
+            }
         }
         pseudoConfig.getRules().add(new PseudoFuncRule(name, pattern, pseudoFunc));
     }

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -167,7 +167,7 @@ class PseudoFieldTest {
     }
 
     @Test
-    void patternWithIndices() {
+    void nameWithIndices() {
         setUpProcessorMocks();
 
         when(recordMapProcessor.hasPreprocessors()).thenReturn(true);

--- a/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
+++ b/src/test/java/no/ssb/dlp/pseudo/service/pseudo/PseudoFieldTest.java
@@ -166,4 +166,21 @@ class PseudoFieldTest {
         verify(recordMapProcessor, times(2)).init(any());
     }
 
+    @Test
+    void patternWithIndices() {
+        setUpProcessorMocks();
+
+        when(recordMapProcessor.hasPreprocessors()).thenReturn(true);
+        when(recordMapProcessor.init(any())).thenReturn(Collections.singletonMap("testField", "initializedValue"));
+
+        PseudoField pseudoField = new PseudoField("path[9]/thing", "**/path/thing", null, null);
+        List<String> values = Arrays.asList("v1", null, "v2");
+
+        Completable result = pseudoField.getPreprocessor(values, recordMapProcessor);
+
+        TestObserver<Void> testObserver = result.test();
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+    }
+
 }


### PR DESCRIPTION
Since `name` is used to contain the paths of hierarchical data, the paths can possibly contain indices. This breaks the glob validation, so we strip array indices before validating. 