### PR TITLE
pom: align gRPC version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <micronaut.openapi.version>7.1.1</micronaut.openapi.version>
     <micronaut.tracing.version>8.2.0</micronaut.tracing.version>
     <micronaut-gcp-version>6.1.0</micronaut-gcp-version>
-    <grpc-netty-shaded-version>1.75.0</grpc-netty-shaded-version>
     <micronaut.validation.version>5.1.0</micronaut.validation.version>
     <auto-service.version>1.1.1</auto-service.version>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
@@ -170,7 +169,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc-netty-shaded-version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
ensure all gRPC packages use the same version
so we don't get runtime mismatches causing runtime
exceptions like:

```
java.lang.NoSuchMethodError: 'void io.grpc.internal.ManagedClientTransport$Listener.transportShutdown(io │
│ .grpc.Status)'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/pseudo-service/253)
<!-- Reviewable:end -->
